### PR TITLE
Set container names and update backend dev script to include prisma generate command

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "server.ts",
   "scripts": {
     "test": "dotenv -e prisma/.env.test -- jest --runInBand --forceExit --detectOpenHandles",
-    "dev": "nodemon -L",
+    "dev": "npx prisma generate && nodemon -L",
     "lint": "eslint . --ext .ts,.js",
     "fix": "eslint . --ext .ts,.js --fix"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 
 services:
   frontend:
+    container_name: sistering_frontend
     build:
       context: ./frontend
       dockerfile: Dockerfile
@@ -15,6 +16,7 @@ services:
     env_file:
       - ./frontend/.env
   backend:
+    container_name: sistering_backend
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -31,6 +33,7 @@ services:
     env_file:
       - ./.env
   db:
+    container_name: sistering_db
     image: postgres:12-alpine
     ports:
       - 5432:5432


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Explicitly set container names in docker-compose.yml so that it is deterministic
* Run `npx prisma generate` as part of backend's `dev` script


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the application (important: update `DB_HOST` in root `.env` file to be sistering_db)
```bash
docker-compose up --build
docker ps
```
You should see these container names:
![image](https://user-images.githubusercontent.com/30205929/139782341-eb1883f9-516b-4fd0-8fd0-3d9952b2452c.png)

2. Check that the `prisma generate` command ran as part of the backend `dev` script, you should see logs like this:
```
backend_1   | Environment variables loaded from prisma/.env
backend_1   | Prisma schema loaded from prisma/schema.prisma
backend_1   |
backend_1   | ✔ Generated Prisma Client (3.3.0) to ./node_modules/@prisma/client in 1.10s
backend_1   | You can now start using Prisma Client in your code. Reference: https://pris.ly/d/client
backend_1   | ```
backend_1   | import { PrismaClient } from '@prisma/client'
backend_1   | const prisma = new PrismaClient()
backend_1   | ```
```
You should no longer see this error:
```
error TS2305: Module '"@prisma/client"' has no exported member 'User'.
```



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
