### PR TITLE
Add .gitattributes file with line endings rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# set line endings to LF for shell scripts
+**/*.sh eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .vscode
 **/*.cache
 **/uploads
+**/firebaseServiceAccount.json


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added .gitattributes file
* Added rule that sets line endings to LF for shell scripts (many Windows users have `autocrlf` git settings enabled which automatically converts line endings to CRLF locally - however Docker is unable to scripts with CRLF, e.g. the `db-init/create-multiple-dbs.sh` script)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
After this PR is merged, Windows users should pull on `main` and ensure that shell scripts have LF line endings


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
