### PR TITLE
Alert Google login error details

### DIFF
--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -19,6 +19,11 @@ import { AuthenticatedUser } from "../../types/AuthTypes";
 
 type GoogleResponse = GoogleLoginResponse | GoogleLoginResponseOffline;
 
+type GoogleErrorResponse = {
+  error: string;
+  details: string;
+};
+
 const LOGIN = gql`
   mutation Login($email: String!, $password: String!) {
     login(email: $email, password: $password) {
@@ -127,13 +132,9 @@ const Login = (): React.ReactElement => {
               window.alert(response);
             }
           }}
-          onFailure={(error) =>
+          onFailure={(error: GoogleErrorResponse) =>
             // eslint-disable-next-line no-alert
-            window.alert(
-              error instanceof Error
-                ? error.message
-                : "Encountered unknown Google Login error.",
-            )
+            window.alert(JSON.stringify(error))
           }
         />
       </form>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
N/A, just a quick fix to display Google login error details properly.


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Correctly typed the Google login error response for future reference
* Stringified error object in alert message, otherwise it will display as `[Object object]`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click on the preview deploy link below
2. Error message should be as follows:
```json
{
    "error": "idpiframe_initialization_failed",
    "details":"Not a valid origin for the client: https://sistering-dev--pr78-sherry-google-login-ulm92vdz.web.app has not been registered for client ID 1076597678761-u9ek25jknj77d37atud522vb4ri1385t.apps.googleusercontent.com. Please go to https://console.developers.google.com/ and register this origin for your project's client ID."
}
```

Note that this error is expected because the preview URL is not listed as an authorized origin for our OAuth client. It does not come up in the staging environment.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Nothing in particular, does it work?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
