### PR TITLE
Add EmployeeUser CRUD and GraphQL Resolvers

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -133,6 +133,8 @@ const authorizedByAdmin = () => isAuthorizedByRole(new Set(["ADMIN"]));
 const authorizedByAdminAndVolunteer = () =>
   isAuthorizedByRole(new Set(["ADMIN", "VOLUNTEER"]));
 const authorizedByVolunteer = () => isAuthorizedByRole(new Set(["VOLUNTEER"]));
+const authorizedByAdminAndEmployee = () =>
+  isAuthorizedByRole(new Set(["ADMIN", "EMPLOYEE"]));
 
 const graphQLMiddlewares = {
   Query: {
@@ -148,6 +150,11 @@ const graphQLMiddlewares = {
     volunteerUserById: authorizedByAdminAndVolunteer(),
     volunteerUserByEmail: authorizedByAdminAndVolunteer(),
     volunteerUsers: authorizedByAdmin(),
+
+    employeeUserById: authorizedByAdminAndEmployee(),
+    employeeUserByEmail: authorizedByAdminAndEmployee(),
+    employeeUsers: authorizedByAdmin(),
+
     skill: authorizedByAdmin(),
     skills: authorizedByAdmin(),
     branch: authorizedByAdmin(),
@@ -166,6 +173,12 @@ const graphQLMiddlewares = {
     updateVolunteerUserById: authorizedByAdminAndVolunteer(),
     deleteVolunteerUserById: authorizedByAdmin(),
     deleteVolunteerUserByEmail: authorizedByAdmin(),
+
+    createEmployeeUser: authorizedByAdminAndEmployee(),
+    updateEmployeeUserById: authorizedByAdminAndEmployee(),
+    deleteEmployeeUserById: authorizedByAdmin(),
+    deleteEmployeeUserByEmail: authorizedByAdmin(),
+
     logout: isAuthorizedByUserId("userId"),
     createShifts: authorizedByAdmin(),
     updateShift: authorizedByAdmin(),

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -150,11 +150,9 @@ const graphQLMiddlewares = {
     volunteerUserById: authorizedByAdminAndVolunteer(),
     volunteerUserByEmail: authorizedByAdminAndVolunteer(),
     volunteerUsers: authorizedByAdmin(),
-
     employeeUserById: authorizedByAdminAndEmployee(),
     employeeUserByEmail: authorizedByAdminAndEmployee(),
     employeeUsers: authorizedByAdmin(),
-
     skill: authorizedByAdmin(),
     skills: authorizedByAdmin(),
     branch: authorizedByAdmin(),
@@ -173,12 +171,10 @@ const graphQLMiddlewares = {
     updateVolunteerUserById: authorizedByAdminAndVolunteer(),
     deleteVolunteerUserById: authorizedByAdmin(),
     deleteVolunteerUserByEmail: authorizedByAdmin(),
-
     createEmployeeUser: authorizedByAdminAndEmployee(),
     updateEmployeeUserById: authorizedByAdminAndEmployee(),
     deleteEmployeeUserById: authorizedByAdmin(),
     deleteEmployeeUserByEmail: authorizedByAdmin(),
-
     logout: isAuthorizedByUserId("userId"),
     createShifts: authorizedByAdmin(),
     updateShift: authorizedByAdmin(),

--- a/backend/graphql/resolvers/userResolvers.ts
+++ b/backend/graphql/resolvers/userResolvers.ts
@@ -12,6 +12,9 @@ import {
   VolunteerUserResponseDTO,
   CreateVolunteerUserDTO,
   UpdateVolunteerUserDTO,
+  EmployeeUserResponseDTO,
+  UpdateEmployeeUserDTO,
+  CreateEmployeeUserDTO,
 } from "../../types";
 import { generateCSV } from "../../utilities/CSVUtils";
 
@@ -57,6 +60,23 @@ const userResolvers = {
     },
     volunteerUsers: async (): Promise<VolunteerUserResponseDTO[]> => {
       return userService.getVolunteerUsers();
+    },
+
+    // EmployeeUsers
+    employeeUserById: async (
+      _parent: undefined,
+      { id }: { id: string },
+    ): Promise<EmployeeUserResponseDTO> => {
+      return userService.getEmployeeUserById(id);
+    },
+    employeeUserByEmail: async (
+      _parent: undefined,
+      { email }: { email: string },
+    ): Promise<EmployeeUserResponseDTO> => {
+      return userService.getEmployeeUserByEmail(email);
+    },
+    employeeUsers: async (): Promise<EmployeeUserResponseDTO[]> => {
+      return userService.getEmployeeUsers();
     },
   },
   Mutation: {
@@ -121,6 +141,39 @@ const userResolvers = {
       { email }: { email: string },
     ): Promise<string> => {
       return userService.deleteVolunteerUserByEmail(email);
+    },
+
+    // EmployeeUsers
+    createEmployeeUser: async (
+      _parent: undefined,
+      { employeeUser }: { employeeUser: CreateEmployeeUserDTO },
+    ): Promise<EmployeeUserResponseDTO> => {
+      const newEmployeeUser = await userService.createEmployeeUser(
+        employeeUser,
+      );
+      await authService.sendEmailVerificationLink(newEmployeeUser.email);
+      return newEmployeeUser;
+    },
+
+    updateEmployeeUserById: async (
+      _parent: undefined,
+      { id, employeeUser }: { id: string; employeeUser: UpdateEmployeeUserDTO },
+    ): Promise<EmployeeUserResponseDTO> => {
+      return userService.updateEmployeeUserById(id, employeeUser);
+    },
+
+    deleteEmployeeUserById: async (
+      _parent: undefined,
+      { id }: { id: string },
+    ): Promise<string> => {
+      return userService.deleteEmployeeUserById(id);
+    },
+
+    deleteEmployeeUserByEmail: async (
+      _parent: undefined,
+      { email }: { email: string },
+    ): Promise<string> => {
+      return userService.deleteEmployeeUserByEmail(email);
     },
   },
 };

--- a/backend/graphql/types/postingType.ts
+++ b/backend/graphql/types/postingType.ts
@@ -44,7 +44,6 @@ const postingType = gql`
 
   type EmployeeResponseDTO {
     id: ID!
-    userId: ID!
     branchId: ID!
   }
 

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -29,6 +29,17 @@ const userType = gql`
     branches: [BranchResponseDTO!]!
   }
 
+  type EmployeeUserResponseDTO {
+    id: ID!
+    firstName: String!
+    lastName: String!
+    email: String!
+    role: Role!
+    phoneNumber: String
+    branchId: ID!
+    postings: [ID!]!
+  }
+
   input CreateUserDTO {
     firstName: String!
     lastName: String!
@@ -71,6 +82,25 @@ const userType = gql`
     branches: [ID!]!
   }
 
+  input CreateEmployeeUserDTO {
+    firstName: String!
+    lastName: String!
+    email: String!
+    phoneNumber: String
+    password: String!
+    branchId: ID!
+    postings: [ID!]!
+  }
+
+  input UpdateEmployeeUserDTO {
+    firstName: String!
+    lastName: String!
+    email: String!
+    phoneNumber: String
+    branchId: ID!
+    postings: [ID!]!
+  }
+
   extend type Query {
     userById(id: ID!): UserDTO!
     userByEmail(email: String!): UserDTO!
@@ -79,6 +109,9 @@ const userType = gql`
     volunteerUserById(id: ID!): VolunteerUserResponseDTO!
     volunteerUserByEmail(email: String!): VolunteerUserResponseDTO!
     volunteerUsers: [VolunteerUserResponseDTO!]!
+    employeeUserById(id: ID!): EmployeeUserResponseDTO!
+    employeeUserByEmail(email: String!): EmployeeUserResponseDTO!
+    employeeUsers: [EmployeeUserResponseDTO!]!
   }
 
   extend type Mutation {
@@ -95,6 +128,15 @@ const userType = gql`
     ): VolunteerUserResponseDTO!
     deleteVolunteerUserById(id: ID!): ID!
     deleteVolunteerUserByEmail(email: String!): ID!
+    createEmployeeUser(
+      employeeUser: CreateEmployeeUserDTO!
+    ): EmployeeUserResponseDTO!
+    updateEmployeeUserById(
+      id: ID!
+      employeeUser: UpdateEmployeeUserDTO!
+    ): EmployeeUserResponseDTO!
+    deleteEmployeeUserById(id: ID!): ID!
+    deleteEmployeeUserByEmail(email: String!): ID!
   }
 `;
 

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -37,7 +37,6 @@ const userType = gql`
     role: Role!
     phoneNumber: String
     branchId: ID!
-    postings: [ID!]!
   }
 
   input CreateUserDTO {
@@ -89,7 +88,6 @@ const userType = gql`
     phoneNumber: String
     password: String!
     branchId: ID!
-    postings: [ID!]!
   }
 
   input UpdateEmployeeUserDTO {
@@ -98,7 +96,6 @@ const userType = gql`
     email: String!
     phoneNumber: String
     branchId: ID!
-    postings: [ID!]!
   }
 
   extend type Query {

--- a/backend/prisma/migrations/20220130202413_remove_user_id_field_for_employee_model/migration.sql
+++ b/backend/prisma/migrations/20220130202413_remove_user_id_field_for_employee_model/migration.sql
@@ -20,4 +20,4 @@ DROP INDEX "volunteers_id_key";
 ALTER TABLE "employees" DROP COLUMN "userId";
 
 -- AddForeignKey
-ALTER TABLE "employees" ADD CONSTRAINT "employees_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "employees" ADD CONSTRAINT "employees_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE CASCADE;

--- a/backend/prisma/migrations/20220130202413_remove_user_id_field_for_employee_model/migration.sql
+++ b/backend/prisma/migrations/20220130202413_remove_user_id_field_for_employee_model/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userId` on the `employees` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "employees" DROP CONSTRAINT "employees_branch_id_fkey";
+
+-- DropIndex
+DROP INDEX "employees_id_key";
+
+-- DropIndex
+DROP INDEX "employees_userId_key";
+
+-- DropIndex
+DROP INDEX "volunteers_id_key";
+
+-- AlterTable
+ALTER TABLE "employees" DROP COLUMN "userId";
+
+-- AddForeignKey
+ALTER TABLE "employees" ADD CONSTRAINT "employees_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -127,7 +127,7 @@ model Signup {
 }
 
 model Volunteer {
-  id              Int                       @unique @id
+  id              Int                       @id
   user            User                      @relation(fields: [id], references: [id], onDelete: Cascade)
   branches        Branch[]                   
   hireDate        DateTime                  @map("hire_date")
@@ -139,11 +139,10 @@ model Volunteer {
 }
 
 model Employee {
-  id       Int       @unique @id
-  userId   Int       @unique
+  id       Int       @id
   user     User      @relation(fields: [id], references: [id], onDelete: Cascade)
   branchId Int       @map("branch_id")
-  branch   Branch    @relation(fields: [branchId], references: [id])
+  branch   Branch    @relation(fields: [branchId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   postings Posting[]
 
   @@map("employees")

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -142,7 +142,7 @@ model Employee {
   id       Int       @id
   user     User      @relation(fields: [id], references: [id], onDelete: Cascade)
   branchId Int       @map("branch_id")
-  branch   Branch    @relation(fields: [branchId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  branch   Branch    @relation(fields: [branchId], references: [id], onDelete: Cascade)
   postings Posting[]
 
   @@map("employees")

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -77,7 +77,6 @@ const convertToEmployeeResponseDTO = (
   return employees.map((employee: Employee) => {
     return {
       id: String(employee.id),
-      userId: String(employee.userId),
       branchId: String(employee.branchId),
     };
   });

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -816,14 +816,6 @@ class UserService implements IUserService {
                 },
               },
             },
-            include: {
-              volunteer: {
-                include: {
-                  branches: true,
-                  skills: true,
-                },
-              },
-            },
           });
         } catch (postgresError: unknown) {
           const errorMessage = [
@@ -857,7 +849,6 @@ class UserService implements IUserService {
         where: { id: Number(userId) },
         include: {
           user: true,
-          postings: true,
         },
       });
 
@@ -876,9 +867,6 @@ class UserService implements IUserService {
         role: user.role,
         phoneNumber: user.phoneNumber,
         branchId: String(employee.branchId),
-        postings: employee.postings.map((p) => {
-          return String(p.id);
-        }),
       };
     } catch (error: unknown) {
       Logger.error(
@@ -898,11 +886,7 @@ class UserService implements IUserService {
           authId: firebaseUser.uid,
         },
         include: {
-          employee: {
-            include: {
-              postings: true,
-            },
-          },
+          employee: true,
         },
       });
 
@@ -920,9 +904,6 @@ class UserService implements IUserService {
         phoneNumber: user.phoneNumber,
         role: user.role,
         branchId: String(employee.branchId),
-        postings: employee.postings.map((p) => {
-          return String(p.id);
-        }),
       };
     } catch (error: unknown) {
       Logger.error(
@@ -939,7 +920,6 @@ class UserService implements IUserService {
       const employees = await prisma.employee.findMany({
         include: {
           user: true,
-          postings: true,
         },
       });
       const employeeUsers = await Promise.all(
@@ -954,9 +934,6 @@ class UserService implements IUserService {
             id: String(employee.id),
             email: firebaseUser.email ?? "",
             branchId: String(employee.branchId),
-            postings: employee.postings.map((p) => {
-              return String(p.id);
-            }),
           };
         }),
       );
@@ -1002,18 +979,11 @@ class UserService implements IUserService {
                 branch: {
                   connect: { id: Number(employeeUser.branchId) },
                 },
-                postings: {
-                  connect: convertToNumberIds(employeeUser.postings),
-                },
               },
             },
           },
           include: {
-            employee: {
-              include: {
-                postings: true,
-              },
-            },
+            employee: true,
           },
         });
 
@@ -1024,9 +994,6 @@ class UserService implements IUserService {
           id: String(newUser.id),
           email: firebaseUser.email ?? "",
           branchId: String(employee!.branchId),
-          postings: employee!.postings.map((p: Posting) => {
-            return String(p.id);
-          }),
         };
       } catch (postgresError) {
         try {
@@ -1083,14 +1050,9 @@ class UserService implements IUserService {
             branch: {
               connect: { id: Number(employeeUser.branchId) },
             },
-            postings: {
-              set: [],
-              connect: convertToNumberIds(employeeUser.postings),
-            },
           },
           include: {
             user: true,
-            postings: true,
           },
         }),
       ]);
@@ -1108,9 +1070,6 @@ class UserService implements IUserService {
           id: String(user.id),
           email: updatedFirebaseUser.email ?? "",
           branchId: String(updatedEmployeeUser.branchId),
-          postings: updatedEmployeeUser.postings.map((p) => {
-            return String(p.id);
-          }),
         };
       } catch (error: unknown) {
         try {
@@ -1202,13 +1161,6 @@ class UserService implements IUserService {
                       return { id: Number(p.id) };
                     }),
                   },
-                },
-              },
-            },
-            include: {
-              employee: {
-                include: {
-                  postings: true,
                 },
               },
             },

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -1,5 +1,5 @@
 import * as firebaseAdmin from "firebase-admin";
-import { PrismaClient, User, Volunteer, Skill, Branch } from "@prisma/client";
+import { PrismaClient, User, Skill, Branch, Posting } from "@prisma/client";
 import IUserService from "../interfaces/userService";
 import {
   CreateUserDTO,
@@ -11,6 +11,9 @@ import {
   UpdateVolunteerUserDTO,
   BranchResponseDTO,
   SkillResponseDTO,
+  CreateEmployeeUserDTO,
+  EmployeeUserResponseDTO,
+  UpdateEmployeeUserDTO,
 } from "../../types";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
@@ -845,6 +848,394 @@ class UserService implements IUserService {
   async deleteVolunteerUserByEmail(email: string): Promise<string> {
     const user = await this.getUserByEmail(email);
     await this.deleteVolunteerUserById(user.id);
+    return String(user.id);
+  }
+
+  async getEmployeeUserById(userId: string): Promise<EmployeeUserResponseDTO> {
+    try {
+      const employee = await prisma.employee.findUnique({
+        where: { id: Number(userId) },
+        include: {
+          user: true,
+          postings: true,
+        },
+      });
+
+      if (!employee) {
+        throw new Error(`Employee with userId ${userId} not found.`);
+      }
+
+      const { user } = employee;
+      const firebaseUser = await firebaseAdmin.auth().getUser(user.authId);
+
+      return {
+        id: String(user.id),
+        email: firebaseUser.email ?? "",
+        firstName: user.firstName,
+        lastName: user.lastName,
+        role: user.role,
+        phoneNumber: user.phoneNumber,
+        branchId: String(employee.branchId),
+        postings: employee.postings.map((p) => {
+          return String(p.id);
+        }),
+      };
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get employee user. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async getEmployeeUserByEmail(
+    email: string,
+  ): Promise<EmployeeUserResponseDTO> {
+    try {
+      const firebaseUser = await firebaseAdmin.auth().getUserByEmail(email);
+      const user = await prisma.user.findUnique({
+        where: {
+          authId: firebaseUser.uid,
+        },
+        include: {
+          employee: {
+            include: {
+              postings: true,
+            },
+          },
+        },
+      });
+
+      if (!user || !user.employee) {
+        throw new Error(`No User or Employee with email ${email}.`);
+      }
+
+      const { employee } = user;
+
+      return {
+        id: String(user.id),
+        email: firebaseUser.email ?? "",
+        firstName: user.firstName,
+        lastName: user.lastName,
+        phoneNumber: user.phoneNumber,
+        role: user.role,
+        branchId: String(employee.branchId),
+        postings: employee.postings.map((p) => {
+          return String(p.id);
+        }),
+      };
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get employee user. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async getEmployeeUsers(): Promise<EmployeeUserResponseDTO[]> {
+    let firebaseUser: firebaseAdmin.auth.UserRecord;
+
+    try {
+      const employees = await prisma.employee.findMany({
+        include: {
+          user: true,
+          postings: true,
+        },
+      });
+      const employeeUsers = await Promise.all(
+        employees.map(async (employee) => {
+          firebaseUser = await firebaseAdmin
+            .auth()
+            .getUser(employee.user.authId!);
+
+          return {
+            ...employee.user,
+            ...employee,
+            id: String(employee.id),
+            email: firebaseUser.email ?? "",
+            branchId: String(employee.branchId),
+            postings: employee.postings.map((p) => {
+              return String(p.id);
+            }),
+          };
+        }),
+      );
+      return employeeUsers;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get employee user. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async createEmployeeUser(
+    employeeUser: CreateEmployeeUserDTO,
+    authId?: string,
+    signUpMethod = "PASSWORD",
+  ): Promise<EmployeeUserResponseDTO> {
+    let firebaseUser: firebaseAdmin.auth.UserRecord;
+
+    try {
+      if (signUpMethod === "GOOGLE") {
+        /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+        firebaseUser = await firebaseAdmin.auth().getUser(authId!);
+      } else {
+        // signUpMethod === PASSWORD
+        firebaseUser = await firebaseAdmin.auth().createUser({
+          email: employeeUser.email,
+          password: employeeUser.password,
+        });
+      }
+
+      try {
+        // nested writes provide transactional guarantees
+        const newUser = await prisma.user.create({
+          data: {
+            firstName: employeeUser.firstName,
+            lastName: employeeUser.lastName,
+            authId: firebaseUser.uid,
+            role: "EMPLOYEE",
+            phoneNumber: employeeUser.phoneNumber,
+            employee: {
+              create: {
+                branch: {
+                  connect: { id: Number(employeeUser.branchId) },
+                },
+                postings: {
+                  connect: convertToNumberIds(employeeUser.postings),
+                },
+              },
+            },
+          },
+          include: {
+            employee: {
+              include: {
+                postings: true,
+              },
+            },
+          },
+        });
+
+        const { employee } = newUser;
+
+        return {
+          ...newUser,
+          id: String(newUser.id),
+          email: firebaseUser.email ?? "",
+          branchId: String(employee!.branchId),
+          postings: employee!.postings.map((p: Posting) => {
+            return String(p.id);
+          }),
+        };
+      } catch (postgresError) {
+        try {
+          await firebaseAdmin.auth().deleteUser(firebaseUser.uid);
+        } catch (firebaseError: unknown) {
+          const errorMessage = [
+            "Failed to rollback Firebase user creation after Postgres user creation failure. Reason =",
+            getErrorMessage(firebaseError),
+            "Orphaned authId (Firebase uid) =",
+            firebaseUser.uid,
+          ];
+          Logger.error(errorMessage.join(" "));
+        }
+
+        throw postgresError;
+      }
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to create EmployeeUser. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async updateEmployeeUserById(
+    userId: string,
+    employeeUser: UpdateEmployeeUserDTO,
+  ): Promise<EmployeeUserResponseDTO> {
+    let updatedFirebaseUser: firebaseAdmin.auth.UserRecord;
+
+    try {
+      const [oldEmployeeUser, updatedEmployeeUser] = await prisma.$transaction([
+        prisma.employee.findUnique({
+          where: {
+            id: Number(userId),
+          },
+          include: {
+            user: true,
+          },
+        }),
+        prisma.employee.update({
+          where: {
+            id: Number(userId),
+          },
+          data: {
+            user: {
+              update: {
+                firstName: employeeUser.firstName,
+                lastName: employeeUser.lastName,
+                role: "EMPLOYEE",
+                phoneNumber: employeeUser.phoneNumber,
+              },
+            },
+            branch: {
+              connect: { id: Number(employeeUser.branchId) },
+            },
+            postings: {
+              set: [],
+              connect: convertToNumberIds(employeeUser.postings),
+            },
+          },
+          include: {
+            user: true,
+            postings: true,
+          },
+        }),
+      ]);
+      try {
+        updatedFirebaseUser = await firebaseAdmin
+          .auth()
+          .updateUser(updatedEmployeeUser.user.authId, {
+            email: employeeUser.email,
+          });
+
+        const { user } = updatedEmployeeUser;
+
+        return {
+          ...user,
+          id: String(user.id),
+          email: updatedFirebaseUser.email ?? "",
+          branchId: String(updatedEmployeeUser.branchId),
+          postings: updatedEmployeeUser.postings.map((p) => {
+            return String(p.id);
+          }),
+        };
+      } catch (error: unknown) {
+        try {
+          prisma.volunteer.update({
+            where: {
+              id: Number(userId),
+            },
+            data: {
+              user: {
+                update: {
+                  firstName: oldEmployeeUser!.user.firstName,
+                  lastName: oldEmployeeUser!.user.lastName,
+                  role: oldEmployeeUser!.user.role,
+                  phoneNumber: oldEmployeeUser!.user.phoneNumber,
+                },
+              },
+            },
+          });
+        } catch (postgresError: unknown) {
+          const errorMessage = [
+            "Failed to rollback Postgres user update after Firebase user update failure. Reason =",
+            getErrorMessage(postgresError),
+            "Postgres user id with possibly inconsistent data =",
+            oldEmployeeUser?.id,
+          ];
+          Logger.error(errorMessage.join(" "));
+        }
+        throw error;
+      }
+    } catch (error: unknown) {
+      Logger.error(`Failed to update user. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
+  async deleteEmployeeUserById(userId: string): Promise<string> {
+    try {
+      /* eslint-disable-next-line @typescript-eslint/naming-convention */
+      const [_, deletedEmployeeUser] = await prisma.$transaction([
+        // use update to remove relations from employee and user before deleting
+        prisma.user.update({
+          where: {
+            id: Number(userId),
+          },
+          data: {
+            employee: {
+              update: {
+                postings: {
+                  set: [],
+                },
+              },
+            },
+          },
+        }),
+        prisma.user.delete({
+          where: {
+            id: Number(userId),
+          },
+          include: {
+            employee: {
+              include: {
+                postings: true,
+                branch: true,
+              },
+            },
+          },
+        }),
+      ]);
+      try {
+        await firebaseAdmin.auth().deleteUser(deletedEmployeeUser.authId);
+      } catch (error: unknown) {
+        // rollback user deletion in Postgres
+        try {
+          const { employee: deletedEmployee } = deletedEmployeeUser;
+          await prisma.user.create({
+            data: {
+              firstName: deletedEmployeeUser.firstName,
+              lastName: deletedEmployeeUser.lastName,
+              authId: deletedEmployeeUser.authId,
+              role: deletedEmployeeUser.role,
+              phoneNumber: deletedEmployeeUser.phoneNumber,
+              employee: {
+                create: {
+                  branch: {
+                    connect: { id: Number(deletedEmployee!.branchId) },
+                  },
+                  postings: {
+                    connect: deletedEmployee!.postings.map((p) => {
+                      return { id: Number(p.id) };
+                    }),
+                  },
+                },
+              },
+            },
+            include: {
+              employee: {
+                include: {
+                  postings: true,
+                },
+              },
+            },
+          });
+        } catch (postgresError: unknown) {
+          const errorMessage = [
+            "Failed to rollback Postgres user deletion after Firebase user deletion failure. Reason =",
+            getErrorMessage(postgresError),
+            "Firebase uid with non-existent Postgres record =",
+            deletedEmployeeUser.authId,
+          ];
+          Logger.error(errorMessage.join(" "));
+        }
+
+        throw error;
+      }
+
+      return String(deletedEmployeeUser.id);
+    } catch (error: unknown) {
+      Logger.error(`Failed to delete user. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
+  async deleteEmployeeUserByEmail(email: string): Promise<string> {
+    const user = await this.getUserByEmail(email);
+    await this.deleteEmployeeUserById(user.id);
     return String(user.id);
   }
 }

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -7,6 +7,9 @@ import {
   VolunteerUserResponseDTO,
   UpdateVolunteerUserDTO,
   CreateVolunteerUserDTO,
+  CreateEmployeeUserDTO,
+  EmployeeUserResponseDTO,
+  UpdateEmployeeUserDTO,
 } from "../../types";
 
 interface IUserService {
@@ -156,6 +159,68 @@ interface IUserService {
    * @throws Error if VolunteerUser deletion fails
    */
   deleteVolunteerUserByEmail(email: string): Promise<string>;
+
+  /**
+   * Get EmployeeUser associated with id
+   * @param id EmployeeUser's id
+   * @returns a EmployeeUserResponseDTO with EmployeeUser's information
+   * @throws Error if EmployeeUser retrieval fails
+   */
+  getEmployeeUserById(userId: string): Promise<EmployeeUserResponseDTO>;
+
+  /**
+   * Get EmployeeUser associated with email
+   * @param email EmployeeUser's email
+   * @returns a EmployeeUserResponseDTO with EmployeeUser's information
+   * @throws Error if EmployeeUser retrieval fails
+   */
+  getEmployeeUserByEmail(email: string): Promise<EmployeeUserResponseDTO>;
+
+  /**
+   * Get all EmployeeUser information (possibly paginated in the future)
+   * @returns array of EmployeeUserResponseDTOs
+   * @throws Error if EmployeeUser retrieval fails
+   */
+  getEmployeeUsers(): Promise<EmployeeUserResponseDTO[]>;
+
+  /**
+   * Create a EmployeeUser, email verification configurable
+   * @param volunteerUser the EmployeeUser to be created
+   * @param authId the EmployeeUser's firebase auth id, optional
+   * @param signUpMethod the method EmployeeUser used to signup
+   * @returns a EmployeeUserResponseDTO with the created EmployeeUser's information
+   * @throws Error if EmployeeUser creation fails
+   */
+  createEmployeeUser(
+    volunteerUser: CreateEmployeeUserDTO,
+  ): Promise<EmployeeUserResponseDTO>;
+
+  /**
+   * Update a EmployeeUser.
+   * Note: the password cannot be updated using this method, use IAuthService.resetPassword instead
+   * @param userId user's id
+   * @param volunteerUser the EmployeeUser to be updated
+   * @returns a EmployeeUserResponseDTO with the updated user's information
+   * @throws Error if EmployeeUser update fails
+   */
+  updateEmployeeUserById(
+    userId: string,
+    volunteerUser: UpdateEmployeeUserDTO,
+  ): Promise<EmployeeUserResponseDTO>;
+
+  /**
+   * Delete a EmployeeUser by id
+   * @param userId user's userId
+   * @throws Error if EmployeeUser deletion fails
+   */
+  deleteEmployeeUserById(userId: string): Promise<string>;
+
+  /**
+   * Delete a EmployeeUser by email
+   * @param email user's email
+   * @throws Error if EmployeeUser deletion fails
+   */
+  deleteEmployeeUserByEmail(email: string): Promise<string>;
 }
 
 export default IUserService;

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -185,14 +185,14 @@ interface IUserService {
 
   /**
    * Create a EmployeeUser, email verification configurable
-   * @param volunteerUser the EmployeeUser to be created
+   * @param employeeUser the EmployeeUser to be created
    * @param authId the EmployeeUser's firebase auth id, optional
    * @param signUpMethod the method EmployeeUser used to signup
    * @returns a EmployeeUserResponseDTO with the created EmployeeUser's information
    * @throws Error if EmployeeUser creation fails
    */
   createEmployeeUser(
-    volunteerUser: CreateEmployeeUserDTO,
+    employeeUser: CreateEmployeeUserDTO,
   ): Promise<EmployeeUserResponseDTO>;
 
   /**
@@ -205,7 +205,7 @@ interface IUserService {
    */
   updateEmployeeUserById(
     userId: string,
-    volunteerUser: UpdateEmployeeUserDTO,
+    employeeUser: UpdateEmployeeUserDTO,
   ): Promise<EmployeeUserResponseDTO>;
 
   /**

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -82,9 +82,7 @@ export type CreateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id"> & {
   password: string;
 };
 
-export type UpdateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id"> & {
-  password: string;
-};
+export type UpdateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id">;
 
 export type CreateUserDTO = Omit<UserDTO, "id"> & { password: string };
 

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -43,7 +43,6 @@ export type PostingResponseDTO = Omit<
 
 export type EmployeeResponseDTO = {
   id: string;
-  userId: string;
   branchId: string;
 };
 
@@ -54,11 +53,6 @@ export type VolunteerDTO = {
   pronouns: string | null;
   skills: SkillResponseDTO[];
   branches: BranchResponseDTO[];
-};
-
-export type EmployeeDTO = {
-  id: string;
-  userId: string;
 };
 
 export type VolunteerUserRequestDTO = UserDTO &
@@ -75,13 +69,21 @@ export type CreateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id"> & {
 
 export type UpdateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id">;
 
-export type EmployeeUserDTO = UserDTO & EmployeeDTO;
+export type EmployeeDTO = {
+  id: string;
+  branchId: string;
+  postings: string[];
+};
 
-export type CreateEmployeeUserDTO = Omit<EmployeeUserDTO, "id"> & {
+export type EmployeeUserRequestDTO = UserDTO & EmployeeDTO;
+
+export type EmployeeUserResponseDTO = UserDTO & EmployeeDTO;
+
+export type CreateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id"> & {
   password: string;
 };
 
-export type UpdateEmployeeUserDTO = Omit<EmployeeUserDTO, "id"> & {
+export type UpdateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id"> & {
   password: string;
 };
 

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -72,7 +72,6 @@ export type UpdateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id">;
 export type EmployeeDTO = {
   id: string;
   branchId: string;
-  postings: string[];
 };
 
 export type EmployeeUserRequestDTO = UserDTO & EmployeeDTO;

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -69,14 +69,14 @@ export type CreateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id"> & {
 
 export type UpdateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id">;
 
-export type EmployeeDTO = {
+export type EmployeeUserDTO = {
   id: string;
   branchId: string;
 };
 
-export type EmployeeUserRequestDTO = UserDTO & EmployeeDTO;
+export type EmployeeUserRequestDTO = UserDTO & EmployeeUserDTO;
 
-export type EmployeeUserResponseDTO = UserDTO & EmployeeDTO;
+export type EmployeeUserResponseDTO = UserDTO & EmployeeUserDTO;
 
 export type CreateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id"> & {
   password: string;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Addresses second half of #29 

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implement CRUD methods:
  - getEmployeeUserById
  - getEmployeeUserByEmail
  - getEmployeeUsers
  - createEmployeeUser
  - updateEmployeeUserById
  - deleteEmployeeUserById
  - deleteEmployeeUserByEmail

* Create corresponding GraphQL resolvers and DTOs


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Start docker and run `docker-compose up --build`
2. Apply the lasted migration files by running `docker exec -it sistering_backend /bin/bash` and `npx prisma migrate deploy`. 
3. We need row(s) in the posting and branch tables for testing. You can either create those using the corresponding GraphQL endpoints or use raw SQL. 
4. Go to http://localhost:5000/graphql
5. Login using an admin user 
6. Then verify that all GraphQL queries and mutations introduced in this ticket work as expected



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Verify that GraphQL endpoints work as expected



## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
