### PR TITLE
Add tag styling to theme

### DIFF
--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -196,14 +196,15 @@ const DesignSystemDisplay = () => {
       <ChakraButton variant="link" isDisabled>
         Link Disabled
       </ChakraButton>
+      <br />
+      <Tag>Default Tag</Tag>
+      <Tag variant="outline">Outline Tag</Tag>
       <Tabs>
         <TabList>
           <Tab>Tab 1</Tab>
           <Tab>Tab 2</Tab>
         </TabList>
       </Tabs>
-      <Tag>Tag</Tag>
-      <Tag variant="outline">Tag</Tag>
     </div>
   );
 };

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -121,7 +121,7 @@ const DesignSystemDisplay = () => {
           },
         ].map((style, index) => (
           <Tag
-            bg={style.backgroundColor}
+            bgColor={style.backgroundColor}
             color={style.textColor}
             size="lg"
             key={index}
@@ -202,6 +202,8 @@ const DesignSystemDisplay = () => {
           <Tab>Tab 2</Tab>
         </TabList>
       </Tabs>
+      <Tag>Tag</Tag>
+      <Tag variant="outline">Tag</Tag>
     </div>
   );
 };

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,4 +1,8 @@
-import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
+import {
+  extendTheme,
+  withDefaultColorScheme,
+  withDefaultProps,
+} from "@chakra-ui/react";
 import { Dict } from "@chakra-ui/utils";
 
 import colors from "./colors";

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,8 +1,4 @@
-import {
-  extendTheme,
-  withDefaultColorScheme,
-  withDefaultProps,
-} from "@chakra-ui/react";
+import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
 import { Dict } from "@chakra-ui/utils";
 
 import colors from "./colors";
@@ -124,6 +120,20 @@ const customTheme = extendTheme(
         baseStyle: {
           label: {
             textStyle: "caption",
+          },
+        },
+        variants: {
+          subtle: {
+            container: {
+              backgroundColor: "green.light",
+              color: "green.dark",
+            },
+          },
+          outline: {
+            container: {
+              color: "text.gray",
+              boxShadow: `inset 0 0 0px 1px ${colors.text.gray}`,
+            },
           },
         },
       },

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -127,12 +127,14 @@ const customTheme = extendTheme(
             container: {
               backgroundColor: "green.light",
               color: "green.dark",
+              borderRadius: "full",
             },
           },
           outline: {
             container: {
               color: "text.gray",
               boxShadow: `inset 0 0 0px 1px ${colors.text.gray}`,
+              borderRadius: "full",
             },
           },
         },


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #132 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The default tag style is now green with dark green text 
* the outline variant is now text.gray

Implementation:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/43686735/152703613-60389b60-9f6d-4cd7-87f0-e6a2ed76b644.png">

Designs: 
<img width="217" alt="image" src="https://user-images.githubusercontent.com/43686735/152703546-968dbe2b-7deb-4590-8bcf-c3c25c747857.png">


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
