### PR TITLE
Add API call functionality to create posting

### DIFF
--- a/frontend/src/components/admin/posting/CreatePostingReview.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingReview.tsx
@@ -31,6 +31,7 @@ const CreatePostingReview = (): React.ReactElement => {
     autoClosingDate,
     times,
   } = useContext(PostingContext);
+
   return (
     <Container maxW="container.xl" p={0}>
       <Flex p={10}>

--- a/frontend/src/components/pages/admin/posting/CreatePostingReviewPage.tsx
+++ b/frontend/src/components/pages/admin/posting/CreatePostingReviewPage.tsx
@@ -1,13 +1,57 @@
-import React from "react";
+import React, { useContext } from "react";
+import { Button } from "@chakra-ui/react";
+import { gql, useMutation } from "@apollo/client";
 
 import CreatePostingReview from "../../../admin/posting/CreatePostingReview";
 import MainPageButton from "../../../common/MainPageButton";
 
+import PostingContext from "../../../../contexts/admin/PostingContext";
+
+const CREATE_POSTING = gql`
+  mutation CreatePosting($posting: PostingRequestDTO!) {
+    createPosting(posting: $posting) {
+      id
+      title
+    }
+  }
+`;
+
 const CreatePostingReviewPage = (): React.ReactElement => {
+  const { status, times, recurrenceInterval, ...postingToCreate } = useContext(
+    PostingContext,
+  );
+  const [createPosting, { data, loading, error }] = useMutation(CREATE_POSTING);
+
+  if (loading) console.log("Submitting...");
+  if (error) console.log(`Submission error! ${error}`);
+
   return (
     <div>
       <CreatePostingReview />
       <MainPageButton />
+      <Button
+        variant="outline"
+        onClick={() => {
+          createPosting({
+            variables: {
+              posting: { ...postingToCreate, ...{ status: "DRAFT" } },
+            },
+          });
+        }}
+      >
+        Save as Draft
+      </Button>
+      <Button
+        onClick={() => {
+          createPosting({
+            variables: {
+              posting: { ...postingToCreate, ...{ status: "PUBLISHED" } },
+            },
+          });
+        }}
+      >
+        Post
+      </Button>
     </div>
   );
 };

--- a/frontend/src/components/pages/admin/posting/CreatePostingReviewPage.tsx
+++ b/frontend/src/components/pages/admin/posting/CreatePostingReviewPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Button } from "@chakra-ui/react";
+import { Button, useBoolean } from "@chakra-ui/react";
 import { gql, useMutation } from "@apollo/client";
 
 import CreatePostingReview from "../../../admin/posting/CreatePostingReview";
@@ -20,10 +20,11 @@ const CreatePostingReviewPage = (): React.ReactElement => {
   const { status, times, recurrenceInterval, ...postingToCreate } = useContext(
     PostingContext,
   );
-  const [createPosting, { data, loading, error }] = useMutation(CREATE_POSTING);
+  const [createPosting, { loading, error }] = useMutation(CREATE_POSTING);
+  const [isDraftClicked, setIsDraftClicked] = useBoolean();
 
-  if (loading) console.log("Submitting...");
-  if (error) console.log(`Submission error! ${error}`);
+  // eslint-disable-next-line no-alert
+  if (error) window.alert(error);
 
   return (
     <div>
@@ -31,10 +32,12 @@ const CreatePostingReviewPage = (): React.ReactElement => {
       <MainPageButton />
       <Button
         variant="outline"
+        isLoading={loading && isDraftClicked}
         onClick={() => {
+          setIsDraftClicked.on();
           createPosting({
             variables: {
-              posting: { ...postingToCreate, ...{ status: "DRAFT" } },
+              posting: { ...postingToCreate, status: "DRAFT" },
             },
           });
         }}
@@ -42,10 +45,12 @@ const CreatePostingReviewPage = (): React.ReactElement => {
         Save as Draft
       </Button>
       <Button
+        isLoading={loading && !isDraftClicked}
         onClick={() => {
+          setIsDraftClicked.off();
           createPosting({
             variables: {
-              posting: { ...postingToCreate, ...{ status: "PUBLISHED" } },
+              posting: { ...postingToCreate, status: "PUBLISHED" },
             },
           });
         }}


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #88 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added the create posting mutation in `CreatePostingReviewPage`
* Added two buttons ("Save as Draft" and "Post") in `CreatePostingReviewPage` that call the create posting mutation
  * Save as Draft: creates posting with status `DRAFT`
  * Post: creates posting with status `PUBLISHED`
* `CreatePostingReviewPage` gets posting data using `PostingContext`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the application locally `docker-compose up --build`
2. Create a branch in your local database for the posting to use
3. Click on the "Edit Posting" tab on the default page and enter the branch id of the branch you just created. 
4. Add other dummy information (be sure to include the dates for "Start Date", "End Date", and "Auto-Closing Date").
5. Click on the "Review Posting" tab and click the "Save as Draft" or "Post" button
6. Check that the posting was successfully created in your local database

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Create posting functionality works as expected
* Correct coding practices for calling API


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
