### PR TITLE
Modify  branch id field on employee model

### DIFF
--- a/backend/prisma/migrations/20220217223601_modify_branch_id_on_employee_model/migration.sql
+++ b/backend/prisma/migrations/20220217223601_modify_branch_id_on_employee_model/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "employees" DROP CONSTRAINT "employees_branch_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "employees" ADD CONSTRAINT "employees_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
When pulling the latest changes from main and running `npx prisma migrate dev`, it generates this migration. It looks like the prev change to this index in `backend\prisma\migrations\20220130202413_remove_user_id_field_for_employee_model\migration.sql` doesn't  include `ON UPDATE`. 

Anyone know why this is happening? .-.