### PR TITLE
Add filtering by status to signups

### DIFF
--- a/backend/graphql/resolvers/shiftSignupResolvers.ts
+++ b/backend/graphql/resolvers/shiftSignupResolvers.ts
@@ -1,3 +1,4 @@
+import { SignupStatus } from "@prisma/client";
 import ShiftSignupService from "../../services/implementations/shiftSignupService";
 import IShiftSignupService from "../../services/interfaces/shiftSignupService";
 import {
@@ -12,9 +13,12 @@ const shiftSignupResolvers = {
   Query: {
     getShiftSignupsForUser: async (
       _parent: undefined,
-      { userId }: { userId: string },
+      {
+        userId,
+        signupStatus,
+      }: { userId: string; signupStatus: SignupStatus | null },
     ): Promise<ShiftSignupResponseDTO[]> => {
-      return shiftSignupService.getShiftSignupsForUser(userId);
+      return shiftSignupService.getShiftSignupsForUser(userId, signupStatus);
     },
   },
   Mutation: {

--- a/backend/graphql/types/shiftSignupType.ts
+++ b/backend/graphql/types/shiftSignupType.ts
@@ -29,7 +29,10 @@ const shiftSignupType = gql`
   }
 
   extend type Query {
-    getShiftSignupsForUser(userId: ID!): [ShiftSignupResponseDTO!]!
+    getShiftSignupsForUser(
+      userId: ID!
+      signupStatus: SignupStatus
+    ): [ShiftSignupResponseDTO!]!
   }
 
   extend type Mutation {

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, Signup, SignupStatus } from "@prisma/client";
+import { Prisma } from ".prisma/client";
 
 import IShiftSignupService from "../interfaces/shiftSignupService";
 import {
@@ -25,10 +26,23 @@ class ShiftSignupService implements IShiftSignupService {
 
   async getShiftSignupsForUser(
     userId: string,
+    signupStatus: SignupStatus | null,
   ): Promise<ShiftSignupResponseDTO[]> {
     try {
+      const filter: Prisma.SignupWhereInput = {
+        AND: [
+          {
+            userId: Number(userId),
+          },
+          signupStatus
+            ? {
+                status: signupStatus,
+              }
+            : {},
+        ],
+      };
       const shiftSignups = await prisma.signup.findMany({
-        where: { userId: Number(userId) },
+        where: filter,
       });
       return shiftSignups.map((signup) => this.convertSignupToDTO(signup));
     } catch (error: unknown) {

--- a/backend/services/interfaces/shiftSignupService.ts
+++ b/backend/services/interfaces/shiftSignupService.ts
@@ -1,3 +1,4 @@
+import { SignupStatus } from "@prisma/client";
 import {
   CreateShiftSignupDTO,
   ShiftSignupResponseDTO,
@@ -35,7 +36,10 @@ interface IShiftSignupService {
    * @returns an array of ShiftSignupResponseDTOs for each shift the user signed up for
    * @throws Error if the shift signup retrieval fails
    */
-  getShiftSignupsForUser(userId: string): Promise<ShiftSignupResponseDTO[]>;
+  getShiftSignupsForUser(
+    userId: string,
+    signupStatus: SignupStatus | null,
+  ): Promise<ShiftSignupResponseDTO[]>;
 }
 
 export default IShiftSignupService;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #126


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* To add filtering by signups to our `getShiftSignupsForUser` endpoint, I added an optional argument for specifying the status of the signup.
  * `getShiftSignupsForUser(id)` -> `getShiftSignupsForUser(id, status)`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. You can populate the db into a testable state by running the commands found in this [PR](https://github.com/uwblueprint/sistering/pull/90)
2. Create some signups using mutations. For example: `mutation {
  createShiftSignups(
    shifts: [{ shiftId: 3, userId: 1, numVolunteers: 3, note: "test" }]
  ) {
    shiftId
    userId
    numVolunteers
    note
  }
}`
3. Test various scenarios to see if the filtering works as expected.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Test to see if the filtering works as behaved.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
