### PR TITLE
Complete volunteer posting card, postings page, postings filter

### DIFF
--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useLayoutEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
 import { Text, Box, HStack, Select } from "@chakra-ui/react";
 
-
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import { dateInRange } from "../../../../utils/DateUtils";
 import { FilterType } from "../../../../types/DateFilterTypes";
@@ -36,7 +35,6 @@ const POSTINGS = gql`
     }
   }
 `;
-
 
 const VolunteerPostingsPage = (): React.ReactElement => {
   const [postings, setPostings] = useState<Posting[] | null>(null);
@@ -158,15 +156,6 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         )}
       </Box>
     </Box>
-//    <div>
-//       <Text textStyle="display-large">Volunteer Postings</Text>
-//       {/* Temp */}
-//       <NoShiftsAvailableTableRow />
-//       <VolunteerAvailabilityTableRow
-//         start={new Date()}
-//         end={new Date(Date.now() + 2 * 1000 * 60 * 60)}
-//       />
-//     </div>
   );
 };
 

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -7,8 +7,6 @@ import { dateInRange } from "../../../../utils/DateUtils";
 import { FilterType } from "../../../../types/DateFilterTypes";
 import PostingCard from "../../../volunteer/PostingCard";
 import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
-import NoShiftsAvailableTableRow from "../../../volunteer/shifts/NoShiftsAvailableTableRow";
-import VolunteerAvailabilityTableRow from "../../../volunteer/shifts/VolunteerAvailabilityTableRow";
 
 type Posting = Omit<
   PostingResponseDTO,

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -67,8 +67,11 @@ import { dateInRange } from "../../../../utils/DateUtils";
 //   },
 // ];
 
-type Posting = Omit<PostingResponseDTO, "shifts" | "employees" | "type" | "numVolunteers" | "status" >;
-type FilterType = "week" | "month" | "all" | ''; 
+type Posting = Omit<
+  PostingResponseDTO,
+  "shifts" | "employees" | "type" | "numVolunteers" | "status"
+>;
+type FilterType = "week" | "month" | "all" | "";
 
 // can refactor this query in the future to be more specific (depending on the data this page needs)
 const POSTINGS = gql`
@@ -91,7 +94,6 @@ const POSTINGS = gql`
     }
   }
 `;
-
 
 const VolunteerPostingsPage = (): React.ReactElement => {
   const [postings, setPostings] = useState<Posting[] | null>(null);
@@ -122,7 +124,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         break;
       default:
         filteredPostings = unfilteredPostings?.filter((posting) =>
-        dateInRange(posting.startDate, "week"),
+          dateInRange(posting.startDate, "week"),
         );
         setPostings(filteredPostings ?? null);
         break;
@@ -130,8 +132,6 @@ const VolunteerPostingsPage = (): React.ReactElement => {
   }, [filter, unfilteredPostings]);
 
   const changeFilter = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(e.target.value)
-    console.log(typeof e.target.value)
     if (e.target.value) {
       setFilter(e.target.value);
     } else {
@@ -155,7 +155,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
   );
 
   return (
-    <Box bg="background.light" pt="48px"  px="101px" pb="64px" minHeight="100vh">
+    <Box bg="background.light" pt="48px" px="101px" pb="64px" minHeight="100vh">
       <Box maxW="1280px" mx="auto">
         <HStack justify="space-between" pb="24px">
           <Text textStyle="display-small-semibold">Events</Text>

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -1,79 +1,18 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useLayoutEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
 import { Text, Box, HStack, Select } from "@chakra-ui/react";
+
 import PostingCard from "../../../volunteer/PostingCard";
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
 import { dateInRange } from "../../../../utils/DateUtils";
-
-// delete before merging to main
-// const postingsArr = [
-//   {
-//     id: "1",
-//     skills: [
-//       { id: "1", name: "CPR" },
-//       { id: "2", name: "WHMIS" },
-//       { id: "3", name: "Photocopying" },
-//     ],
-//     branch: {
-//       id: "1",
-//       name: "branch name",
-//     },
-//     title: "Medical Reception Volunteer",
-//     startDate: new Date("Feb 28, 2022"),
-//     endDate: new Date("March 20, 2022"),
-//     autoClosingDate: new Date("Monday, November 30"),
-//     isSignedUp: false,
-//     description:
-//       "Volunteers will be responsible for updating the inventory monthly, updating the manuals and guidelines on an ongoing basis, uploading the COVID-19 screenings on a weekly basis.",
-//   },
-//   {
-//     id: "2",
-//     skills: [
-//       { id: "1", name: "CPR" },
-//       { id: "2", name: "WHMIS" },
-//       { id: "3", name: "Photocopying" },
-//     ],
-//     branch: {
-//       id: "1",
-//       name: "sample text",
-//     },
-//     title: "Medical Reception Volunteer",
-//     startDate: new Date("February 14, 2022"),
-//     endDate: new Date("March 20, 2022"),
-//     autoClosingDate: new Date("Monday, November 30"),
-//     isSignedUp: false,
-//     description:
-//       "Volunteers will be responsible for updating the inventory monthly, updating the manuals and guidelines on an ongoing basis, uploading the COVID-19 screenings on a weekly basis.",
-//   },
-//   {
-//     id: "3",
-//     skills: [
-//       { id: "1", name: "CPR" },
-//       { id: "2", name: "WHMIS" },
-//       { id: "3", name: "Photocopying" },
-//     ],
-//     branch: {
-//       id: "1",
-//       name: "sample text",
-//     },
-//     title: "Medical Reception Volunteer",
-//     startDate: new Date("March 18, 2022"),
-//     endDate: new Date("March 20, 2022"),
-//     autoClosingDate: new Date("Monday, November 30"),
-//     isSignedUp: false,
-//     description:
-//       "Volunteers will be responsible for updating the inventory monthly, updating the manuals and guidelines on an ongoing basis, uploading the COVID-19 screenings on a weekly basis.",
-//   },
-// ];
+import { FilterType } from "../../../../types/DateFilterTypes";
 
 type Posting = Omit<
   PostingResponseDTO,
   "shifts" | "employees" | "type" | "numVolunteers" | "status"
 >;
-type FilterType = "week" | "month" | "all" | "";
 
-// can refactor this query in the future to be more specific (depending on the data this page needs)
 const POSTINGS = gql`
   query VolunteerPostingsPage_postings {
     postings {
@@ -100,7 +39,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
   const [unfilteredPostings, setUnfilteredPostings] = useState<
     Posting[] | null
   >(null);
-  const [filter, setFilter] = useState<string>("week");
+  const [filter, setFilter] = useState<FilterType>("week");
 
   useQuery(POSTINGS, {
     fetchPolicy: "cache-and-network",
@@ -110,7 +49,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
     },
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     let filteredPostings;
     switch (filter) {
       case "month":
@@ -132,14 +71,11 @@ const VolunteerPostingsPage = (): React.ReactElement => {
   }, [filter, unfilteredPostings]);
 
   const changeFilter = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (e.target.value) {
-      setFilter(e.target.value);
-    } else {
-      setFilter("week");
-    }
+    const value: FilterType = e.target.value as FilterType;
+    setFilter(value);
   };
 
-  // need to refactor this function based on definition of what is an opportunity / event
+  // TODO: need to refactor this function based on definition of what is an opportunity / event
   const isVolunteerOpportunity = (start: string, end: string): boolean => {
     const startDate = new Date(start);
     const endDate = new Date(end);
@@ -163,12 +99,13 @@ const VolunteerPostingsPage = (): React.ReactElement => {
             <Text>Showing: </Text>
             <Select
               width="194px"
-              placeholder="This week"
+              defaultValue="week"
               size="sm"
               bg="white"
               borderRadius="4px"
               onChange={changeFilter}
             >
+              <option value="week">This week</option>
               <option value="month">This month</option>
               <option value="all">All shifts</option>
             </Select>

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -1,11 +1,234 @@
-import React from "react";
-import { Text } from "@chakra-ui/react";
+import React, { useState, useEffect } from "react";
+import { gql, useQuery } from "@apollo/client";
+import { Text, Box, HStack, Select } from "@chakra-ui/react";
+import PostingCard from "../../../volunteer/PostingCard";
+import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
+import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
+
+// delete before merging to main
+// const postingsArr = [
+//   {
+//     id: "1",
+//     skills: [
+//       { id: "1", name: "CPR" },
+//       { id: "2", name: "WHMIS" },
+//       { id: "3", name: "Photocopying" },
+//     ],
+//     branch: {
+//       id: "1",
+//       name: "branch name",
+//     },
+//     title: "Medical Reception Volunteer",
+//     startDate: new Date("Feb 28, 2022"),
+//     endDate: new Date("March 20, 2022"),
+//     autoClosingDate: new Date("Monday, November 30"),
+//     isSignedUp: false,
+//     description:
+//       "Volunteers will be responsible for updating the inventory monthly, updating the manuals and guidelines on an ongoing basis, uploading the COVID-19 screenings on a weekly basis.",
+//   },
+//   {
+//     id: "2",
+//     skills: [
+//       { id: "1", name: "CPR" },
+//       { id: "2", name: "WHMIS" },
+//       { id: "3", name: "Photocopying" },
+//     ],
+//     branch: {
+//       id: "1",
+//       name: "sample text",
+//     },
+//     title: "Medical Reception Volunteer",
+//     startDate: new Date("February 14, 2022"),
+//     endDate: new Date("March 20, 2022"),
+//     autoClosingDate: new Date("Monday, November 30"),
+//     isSignedUp: false,
+//     description:
+//       "Volunteers will be responsible for updating the inventory monthly, updating the manuals and guidelines on an ongoing basis, uploading the COVID-19 screenings on a weekly basis.",
+//   },
+//   {
+//     id: "3",
+//     skills: [
+//       { id: "1", name: "CPR" },
+//       { id: "2", name: "WHMIS" },
+//       { id: "3", name: "Photocopying" },
+//     ],
+//     branch: {
+//       id: "1",
+//       name: "sample text",
+//     },
+//     title: "Medical Reception Volunteer",
+//     startDate: new Date("March 18, 2022"),
+//     endDate: new Date("March 20, 2022"),
+//     autoClosingDate: new Date("Monday, November 30"),
+//     isSignedUp: false,
+//     description:
+//       "Volunteers will be responsible for updating the inventory monthly, updating the manuals and guidelines on an ongoing basis, uploading the COVID-19 screenings on a weekly basis.",
+//   },
+// ];
+
+// can refactor this query in the future to be more specific (depending on the data this page needs)
+const POSTINGS = gql`
+  query VolunteerPostingsPage_postings {
+    postings {
+      id
+      branch {
+        id
+        name
+      }
+      shifts {
+        id
+        postingId
+        startTime
+        endTime
+      }
+      skills {
+        id
+        name
+      }
+      employees {
+        id
+        branchId
+      }
+      title
+      type
+      status
+      description
+      startDate
+      endDate
+      autoClosingDate
+      numVolunteers
+    }
+  }
+`;
+
+const MS_PER_WEEK = 604800000;
+
 
 const VolunteerPostingsPage = (): React.ReactElement => {
+
+  const [postings, setPostings] = useState<PostingResponseDTO[] | null>(null);
+  const [unfilteredPostings, setUnfilteredPostings] = useState<PostingResponseDTO[] | null>(null);
+  const [filter, setFilter] = useState<string>('week')
+
+  useQuery(POSTINGS, {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      setPostings(data.postings)
+      setUnfilteredPostings(data.postings)
+  }}
+  );
+
+
+  // should posting.startDate type be declared as string instead on frontend?
+  const dateCompareUtil = (start: Date, filterType: string):boolean => {
+    const startDate = new Date(start);
+    return startDate.getTime() - Date.now() > 0 && startDate.getTime() - Date.now() < (filterType === 'week' ? MS_PER_WEEK : MS_PER_WEEK * 4)
+  }
+
+  useEffect(() => {
+    let filteredPostings;
+      switch (filter) {
+        case 'month': 
+          filteredPostings = unfilteredPostings?.filter(posting => dateCompareUtil(posting.startDate, 'month'))
+          setPostings(filteredPostings ?? null)
+          break;
+        case 'all':
+          setPostings(unfilteredPostings);
+          break;
+        default:
+          filteredPostings = unfilteredPostings?.filter(posting => dateCompareUtil(posting.startDate, 'week'))
+          setPostings(filteredPostings ?? null)
+          break;
+      }
+      console.log(filteredPostings)
+  }, [filter, unfilteredPostings])
+
+  const changeFilter = (e:React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value) {
+      setFilter(e.target.value)
+    } else {
+      setFilter('week')
+    }
+  }
+
+  // need to refactor this function based on definition of what is an opportunity / event
+  const isVolunteerOpportunity = (start: Date, end: Date): boolean => {
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+
+    return endDate.getTime() - startDate.getTime() > 1000 * 60 * 60 * 24;
+  };
+
+  const volunteerOpportunities = postings?.filter((posting) =>
+    isVolunteerOpportunity(posting.startDate, posting.endDate),
+  );
+  const events = postings?.filter(
+    (posting) => !isVolunteerOpportunity(posting.startDate, posting.endDate),
+  );
+
   return (
-    <div>
-      <Text textStyle="display-large">Volunteer Postings</Text>
-    </div>
+    <Box bg="background.light" pt="48px" minHeight="100vh">
+      <Box maxW="1280px" mx="auto">
+        <HStack justify="space-between" bg="#F4F4F4" pb="36px">
+          <Text textStyle="display-small-semibold">Events</Text>
+          <HStack>
+            <Text>Showing: </Text>
+            <Select
+              width="194px"
+              placeholder="This week"
+              size="sm"
+              bg="white"
+              borderRadius="4px"
+              onChange={changeFilter}
+            >
+              <option value="month">This month</option>
+              <option value="all">All shifts</option>
+            </Select>
+          </HStack>
+        </HStack>
+        {events && events.length > 0 ? (
+          events.map((posting) => (
+            <Box key={posting.id} pt="36px">
+              <PostingCard
+                key={posting.id}
+                id={posting.id}
+                skills={posting.skills}
+                title={posting.title}
+                startDate={posting.startDate}
+                endDate={posting.endDate}
+                autoClosingDate={posting.autoClosingDate}
+                description={posting.description}
+                branchName={posting.branch.name}
+              />
+            </Box>
+          ))
+        ) : (
+          <EmptyPostingCard type="event" />
+        )}
+        <Text textStyle="display-small-semibold" pb="36px">
+          Volunteer Opportunities
+        </Text>
+        {volunteerOpportunities && volunteerOpportunities.length > 0 ? (
+          volunteerOpportunities.map((posting) => (
+            <Box key={posting.id} pb="36px">
+              <PostingCard
+                key={posting.id}
+                id={posting.id}
+                skills={posting.skills}
+                title={posting.title}
+                startDate={posting.startDate}
+                endDate={posting.endDate}
+                autoClosingDate={posting.autoClosingDate}
+                description={posting.description}
+                branchName={posting.branch.name}
+              />
+            </Box>
+          ))
+        ) : (
+          <EmptyPostingCard type="volunteer" />
+        )}
+      </Box>
+    </Box>
   );
 };
 

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -4,6 +4,7 @@ import { Text, Box, HStack, Select } from "@chakra-ui/react";
 import PostingCard from "../../../volunteer/PostingCard";
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
+import { dateInRange } from "../../../../utils/DateUtils";
 
 // delete before merging to main
 // const postingsArr = [
@@ -66,6 +67,9 @@ import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
 //   },
 // ];
 
+type Posting = Omit<PostingResponseDTO, "shifts" | "employees" | "type" | "numVolunteers" | "status" >;
+type FilterType = "week" | "month" | "all" | ''; 
+
 // can refactor this query in the future to be more specific (depending on the data this page needs)
 const POSTINGS = gql`
   query VolunteerPostingsPage_postings {
@@ -75,38 +79,24 @@ const POSTINGS = gql`
         id
         name
       }
-      shifts {
-        id
-        postingId
-        startTime
-        endTime
-      }
       skills {
         id
         name
       }
-      employees {
-        id
-        branchId
-      }
       title
-      type
-      status
       description
       startDate
       endDate
       autoClosingDate
-      numVolunteers
     }
   }
 `;
 
-const MS_PER_WEEK = 604800000;
 
 const VolunteerPostingsPage = (): React.ReactElement => {
-  const [postings, setPostings] = useState<PostingResponseDTO[] | null>(null);
+  const [postings, setPostings] = useState<Posting[] | null>(null);
   const [unfilteredPostings, setUnfilteredPostings] = useState<
-    PostingResponseDTO[] | null
+    Posting[] | null
   >(null);
   const [filter, setFilter] = useState<string>("week");
 
@@ -118,22 +108,12 @@ const VolunteerPostingsPage = (): React.ReactElement => {
     },
   });
 
-  // should posting.startDate type be declared as string instead on frontend?
-  const dateCompareUtil = (start: Date, filterType: string): boolean => {
-    const startDate = new Date(start);
-    return (
-      startDate.getTime() - Date.now() > 0 &&
-      startDate.getTime() - Date.now() <
-        (filterType === "week" ? MS_PER_WEEK : MS_PER_WEEK * 4)
-    );
-  };
-
   useEffect(() => {
     let filteredPostings;
     switch (filter) {
       case "month":
         filteredPostings = unfilteredPostings?.filter((posting) =>
-          dateCompareUtil(posting.startDate, "month"),
+          dateInRange(posting.startDate, "month"),
         );
         setPostings(filteredPostings ?? null);
         break;
@@ -142,7 +122,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         break;
       default:
         filteredPostings = unfilteredPostings?.filter((posting) =>
-          dateCompareUtil(posting.startDate, "week"),
+        dateInRange(posting.startDate, "week"),
         );
         setPostings(filteredPostings ?? null);
         break;
@@ -150,6 +130,8 @@ const VolunteerPostingsPage = (): React.ReactElement => {
   }, [filter, unfilteredPostings]);
 
   const changeFilter = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log(e.target.value)
+    console.log(typeof e.target.value)
     if (e.target.value) {
       setFilter(e.target.value);
     } else {
@@ -158,7 +140,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
   };
 
   // need to refactor this function based on definition of what is an opportunity / event
-  const isVolunteerOpportunity = (start: Date, end: Date): boolean => {
+  const isVolunteerOpportunity = (start: string, end: string): boolean => {
     const startDate = new Date(start);
     const endDate = new Date(end);
 
@@ -173,9 +155,9 @@ const VolunteerPostingsPage = (): React.ReactElement => {
   );
 
   return (
-    <Box bg="background.light" pt="48px" minHeight="100vh">
+    <Box bg="background.light" pt="48px"  px="101px" pb="64px" minHeight="100vh">
       <Box maxW="1280px" mx="auto">
-        <HStack justify="space-between" bg="#F4F4F4" pb="36px">
+        <HStack justify="space-between" pb="24px">
           <Text textStyle="display-small-semibold">Events</Text>
           <HStack>
             <Text>Showing: </Text>
@@ -194,7 +176,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         </HStack>
         {events && events.length > 0 ? (
           events.map((posting) => (
-            <Box key={posting.id} pt="36px">
+            <Box key={posting.id} pb="24px">
               <PostingCard
                 key={posting.id}
                 id={posting.id}
@@ -211,12 +193,12 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         ) : (
           <EmptyPostingCard type="event" />
         )}
-        <Text textStyle="display-small-semibold" pb="36px">
+        <Text textStyle="display-small-semibold" pb="24px" pt="24px">
           Volunteer Opportunities
         </Text>
         {volunteerOpportunities && volunteerOpportunities.length > 0 ? (
           volunteerOpportunities.map((posting) => (
-            <Box key={posting.id} pb="36px">
+            <Box key={posting.id} pb="24px">
               <PostingCard
                 key={posting.id}
                 id={posting.id}
@@ -231,7 +213,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
             </Box>
           ))
         ) : (
-          <EmptyPostingCard type="volunteer" />
+          <EmptyPostingCard type="opportunity" />
         )}
       </Box>
     </Box>

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -103,53 +103,59 @@ const POSTINGS = gql`
 
 const MS_PER_WEEK = 604800000;
 
-
 const VolunteerPostingsPage = (): React.ReactElement => {
-
   const [postings, setPostings] = useState<PostingResponseDTO[] | null>(null);
-  const [unfilteredPostings, setUnfilteredPostings] = useState<PostingResponseDTO[] | null>(null);
-  const [filter, setFilter] = useState<string>('week')
+  const [unfilteredPostings, setUnfilteredPostings] = useState<
+    PostingResponseDTO[] | null
+  >(null);
+  const [filter, setFilter] = useState<string>("week");
 
   useQuery(POSTINGS, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
-      setPostings(data.postings)
-      setUnfilteredPostings(data.postings)
-  }}
-  );
-
+      setPostings(data.postings);
+      setUnfilteredPostings(data.postings);
+    },
+  });
 
   // should posting.startDate type be declared as string instead on frontend?
-  const dateCompareUtil = (start: Date, filterType: string):boolean => {
+  const dateCompareUtil = (start: Date, filterType: string): boolean => {
     const startDate = new Date(start);
-    return startDate.getTime() - Date.now() > 0 && startDate.getTime() - Date.now() < (filterType === 'week' ? MS_PER_WEEK : MS_PER_WEEK * 4)
-  }
+    return (
+      startDate.getTime() - Date.now() > 0 &&
+      startDate.getTime() - Date.now() <
+        (filterType === "week" ? MS_PER_WEEK : MS_PER_WEEK * 4)
+    );
+  };
 
   useEffect(() => {
     let filteredPostings;
-      switch (filter) {
-        case 'month': 
-          filteredPostings = unfilteredPostings?.filter(posting => dateCompareUtil(posting.startDate, 'month'))
-          setPostings(filteredPostings ?? null)
-          break;
-        case 'all':
-          setPostings(unfilteredPostings);
-          break;
-        default:
-          filteredPostings = unfilteredPostings?.filter(posting => dateCompareUtil(posting.startDate, 'week'))
-          setPostings(filteredPostings ?? null)
-          break;
-      }
-      console.log(filteredPostings)
-  }, [filter, unfilteredPostings])
-
-  const changeFilter = (e:React.ChangeEvent<HTMLSelectElement>) => {
-    if (e.target.value) {
-      setFilter(e.target.value)
-    } else {
-      setFilter('week')
+    switch (filter) {
+      case "month":
+        filteredPostings = unfilteredPostings?.filter((posting) =>
+          dateCompareUtil(posting.startDate, "month"),
+        );
+        setPostings(filteredPostings ?? null);
+        break;
+      case "all":
+        setPostings(unfilteredPostings);
+        break;
+      default:
+        filteredPostings = unfilteredPostings?.filter((posting) =>
+          dateCompareUtil(posting.startDate, "week"),
+        );
+        setPostings(filteredPostings ?? null);
+        break;
     }
-  }
+  }, [filter, unfilteredPostings]);
+
+  const changeFilter = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value) {
+      setFilter(e.target.value);
+    } else {
+      setFilter("week");
+    }
+  };
 
   // need to refactor this function based on definition of what is an opportunity / event
   const isVolunteerOpportunity = (start: Date, end: Date): boolean => {

--- a/frontend/src/components/volunteer/EmptyPostingCard.tsx
+++ b/frontend/src/components/volunteer/EmptyPostingCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Text, Box, VStack } from "@chakra-ui/react";
 
 type EmptyPostingCardProps = {
-  type: string;
+  type: "event" | "opportunity";
 };
 
 const EmptyPostingCard = ({
@@ -14,10 +14,9 @@ const EmptyPostingCard = ({
       borderWidth="2px"
       borderColor="background.dark"
       bg="background.white"
-      mb="36px"
+      height="121px"
     >
-      <VStack justify="center" align="center" height="121px">
-        <Box>
+      <VStack justify="center" align="center" h="full">
           <Text
             textStyle="body-regular"
             textAlign="center"
@@ -28,7 +27,6 @@ const EmptyPostingCard = ({
             {type === "event" ? "events" : "regular volunteer opportunities"} at
             this time. Please check back soon.
           </Text>
-        </Box>
       </VStack>
     </Box>
   );

--- a/frontend/src/components/volunteer/EmptyPostingCard.tsx
+++ b/frontend/src/components/volunteer/EmptyPostingCard.tsx
@@ -5,7 +5,9 @@ type EmptyPostingCardProps = {
   type: string;
 };
 
-const EmptyPostingCard = ({ type }: EmptyPostingCardProps): React.ReactElement => {
+const EmptyPostingCard = ({
+  type,
+}: EmptyPostingCardProps): React.ReactElement => {
   return (
     <Box
       borderRadius="8px"
@@ -16,7 +18,12 @@ const EmptyPostingCard = ({ type }: EmptyPostingCardProps): React.ReactElement =
     >
       <VStack justify="center" align="center" height="121px">
         <Box>
-          <Text textStyle="body-regular" textAlign="center" my="auto" color="text.gray">
+          <Text
+            textStyle="body-regular"
+            textAlign="center"
+            my="auto"
+            color="text.gray"
+          >
             There are no{" "}
             {type === "event" ? "events" : "regular volunteer opportunities"} at
             this time. Please check back soon.

--- a/frontend/src/components/volunteer/EmptyPostingCard.tsx
+++ b/frontend/src/components/volunteer/EmptyPostingCard.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Text, Box, VStack } from "@chakra-ui/react";
+
+type EmptyPostingCardProps = {
+  type: string;
+};
+
+const EmptyPostingCard = ({ type }: EmptyPostingCardProps): React.ReactElement => {
+  return (
+    <Box
+      borderRadius="8px"
+      borderWidth="2px"
+      borderColor="background.dark"
+      bg="background.white"
+      mb="36px"
+    >
+      <VStack justify="center" align="center" height="121px">
+        <Box>
+          <Text textStyle="body-regular" textAlign="center" my="auto" color="text.gray">
+            There are no{" "}
+            {type === "event" ? "events" : "regular volunteer opportunities"} at
+            this time. Please check back soon.
+          </Text>
+        </Box>
+      </VStack>
+    </Box>
+  );
+};
+
+export default EmptyPostingCard;

--- a/frontend/src/components/volunteer/EmptyPostingCard.tsx
+++ b/frontend/src/components/volunteer/EmptyPostingCard.tsx
@@ -17,16 +17,16 @@ const EmptyPostingCard = ({
       height="121px"
     >
       <VStack justify="center" align="center" h="full">
-          <Text
-            textStyle="body-regular"
-            textAlign="center"
-            my="auto"
-            color="text.gray"
-          >
-            There are no{" "}
-            {type === "event" ? "events" : "regular volunteer opportunities"} at
-            this time. Please check back soon.
-          </Text>
+        <Text
+          textStyle="body-regular"
+          textAlign="center"
+          my="auto"
+          color="text.gray"
+        >
+          There are no{" "}
+          {type === "event" ? "events" : "regular volunteer opportunities"} at
+          this time. Please check back soon.
+        </Text>
       </VStack>
     </Box>
   );

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { TimeIcon, CalendarIcon } from "@chakra-ui/icons";
+import {
+  Text,
+  Box,
+  VStack,
+  HStack,
+  Divider,
+  Button,
+  ButtonGroup,
+  Tag,
+} from "@chakra-ui/react";
+import {formatDateStringWithYear} from '../../utils/DateUtils';
+
+
+type PostingCardProps = {
+  id: string;
+  title: string;
+  skills: SkillResponseDTO[];
+  description: string;
+  startDate: Date;
+  endDate: Date;
+  autoClosingDate: Date;
+  branchName: string;
+};
+
+type SkillResponseDTO = {
+  id: string;
+  name: string;
+};
+
+const PostingCard = ({
+  id,
+  title,
+  skills,
+  description,
+  startDate,
+  endDate,
+  autoClosingDate,
+  branchName,
+}: PostingCardProps): React.ReactElement => {
+  return (
+    <Box
+      bg="white"
+      borderRadius="8px"
+      border="2px solid"
+      borderColor="background.dark"
+      id={id}
+    >
+      <VStack px="36px" py="40px" align="start" spacing="12px">
+        <Tag>{branchName}</Tag>
+        <Text textStyle="heading">{title}</Text>
+        <HStack spacing={4}>
+          {/* toAdd: conditionally displaying time for event listings */}
+          <Text textStyle="caption" noOfLines={2}>
+            <TimeIcon w={4} pr={1} />
+            See Posting Details
+          </Text>
+          <Text textStyle="caption">
+            <CalendarIcon w={4} pr={1} />
+            {`${formatDateStringWithYear(startDate)} - ${formatDateStringWithYear(endDate)}`}
+          </Text>
+        </HStack>
+        <Text textStyle="body-regular" noOfLines={2}>
+          {description}
+        </Text>
+        <HStack>
+          <Text textStyle="body-regular">Skills: </Text>
+          {skills.slice(0, 5).map((skill) => (
+            <Tag variant="outline" key={skill.id}>
+              {skill.name}
+            </Tag>
+          ))}
+        </HStack>
+        <Box w="100%" h='100%' mt='16px !important' mb='4px !important'>
+        <Divider/>
+        </Box>
+        <HStack justifyContent="space-between" w="100%">
+          <Text textStyle="caption" color="text.gray">
+            Deadline:{" "}
+            {formatDateStringWithYear(autoClosingDate)}
+          </Text>
+          <ButtonGroup spacing="10px" size="md">
+            <Button variant="ghost">View Details</Button>
+            <Button variant="solid">Submit Availability</Button>
+          </ButtonGroup>
+        </HStack>
+      </VStack>
+    </Box>
+  );
+};
+
+export default PostingCard;

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -10,6 +10,7 @@ import {
   ButtonGroup,
   Tag,
 } from "@chakra-ui/react";
+
 import { formatDateStringWithYear } from "../../utils/DateUtils";
 import { SkillResponseDTO } from "../../types/api/SkillTypes";
 
@@ -46,7 +47,7 @@ const PostingCard = ({
         <Tag>{branchName}</Tag>
         <Text textStyle="heading">{title}</Text>
         <HStack spacing={4}>
-          {/* toAdd: conditionally displaying time for event listings */}
+          {/* TODO: conditionally displaying time for event listings */}
           <Text textStyle="caption" noOfLines={2}>
             <TimeIcon w={4} pr={1} />
             See Posting Details

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -11,21 +11,17 @@ import {
   Tag,
 } from "@chakra-ui/react";
 import { formatDateStringWithYear } from "../../utils/DateUtils";
+import {SkillResponseDTO} from '../../types/api/SkillTypes';
 
 type PostingCardProps = {
   id: string;
   title: string;
   skills: SkillResponseDTO[];
   description: string;
-  startDate: Date;
-  endDate: Date;
-  autoClosingDate: Date;
+  startDate: string;
+  endDate: string;
+  autoClosingDate: string;
   branchName: string;
-};
-
-type SkillResponseDTO = {
-  id: string;
-  name: string;
 };
 
 const PostingCard = ({
@@ -46,7 +42,7 @@ const PostingCard = ({
       borderColor="background.dark"
       id={id}
     >
-      <VStack px="36px" py="40px" align="start" spacing="12px">
+      <VStack px="40px" py="36px" align="start" spacing="12px">
         <Tag>{branchName}</Tag>
         <Text textStyle="heading">{title}</Text>
         <HStack spacing={4}>

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -11,7 +11,7 @@ import {
   Tag,
 } from "@chakra-ui/react";
 import { formatDateStringWithYear } from "../../utils/DateUtils";
-import {SkillResponseDTO} from '../../types/api/SkillTypes';
+import { SkillResponseDTO } from "../../types/api/SkillTypes";
 
 type PostingCardProps = {
   id: string;

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -10,8 +10,7 @@ import {
   ButtonGroup,
   Tag,
 } from "@chakra-ui/react";
-import {formatDateStringWithYear} from '../../utils/DateUtils';
-
+import { formatDateStringWithYear } from "../../utils/DateUtils";
 
 type PostingCardProps = {
   id: string;
@@ -58,7 +57,9 @@ const PostingCard = ({
           </Text>
           <Text textStyle="caption">
             <CalendarIcon w={4} pr={1} />
-            {`${formatDateStringWithYear(startDate)} - ${formatDateStringWithYear(endDate)}`}
+            {`${formatDateStringWithYear(
+              startDate,
+            )} - ${formatDateStringWithYear(endDate)}`}
           </Text>
         </HStack>
         <Text textStyle="body-regular" noOfLines={2}>
@@ -72,13 +73,12 @@ const PostingCard = ({
             </Tag>
           ))}
         </HStack>
-        <Box w="100%" h='100%' mt='16px !important' mb='4px !important'>
-        <Divider/>
+        <Box w="100%" h="100%" mt="16px !important" mb="4px !important">
+          <Divider />
         </Box>
         <HStack justifyContent="space-between" w="100%">
           <Text textStyle="caption" color="text.gray">
-            Deadline:{" "}
-            {formatDateStringWithYear(autoClosingDate)}
+            Deadline: {formatDateStringWithYear(autoClosingDate)}
           </Text>
           <ButtonGroup spacing="10px" size="md">
             <Button variant="ghost">View Details</Button>

--- a/frontend/src/types/DateFilterTypes.ts
+++ b/frontend/src/types/DateFilterTypes.ts
@@ -1,0 +1,1 @@
+export type FilterType = "week" | "month" | "all";

--- a/frontend/src/types/api/EmployeeTypes.ts
+++ b/frontend/src/types/api/EmployeeTypes.ts
@@ -1,5 +1,4 @@
 export type EmployeeResponseDTO = {
   id: string;
-  userId: string;
   branchId: string;
 };

--- a/frontend/src/types/api/PostingTypes.ts
+++ b/frontend/src/types/api/PostingTypes.ts
@@ -16,9 +16,9 @@ export type PostingDTO = {
   type: PostingType;
   status: PostingStatus;
   description: string;
-  startDate: Date;
-  endDate: Date;
-  autoClosingDate: Date;
+  startDate: string;
+  endDate: string;
+  autoClosingDate: string;
   numVolunteers: number;
 };
 

--- a/frontend/src/utils/DateUtils.ts
+++ b/frontend/src/utils/DateUtils.ts
@@ -1,3 +1,5 @@
+import { FilterType } from "../types/DateFilterTypes";
+
 // eslint-disable-next-line import/prefer-default-export
 export const formatDateString = (dateStringInput: string): string => {
   const date = new Date(dateStringInput);
@@ -21,7 +23,7 @@ export const formatDateStringWithYear = (dateStringInput: string): string => {
 };
 
 // currently only supports filter by week and month
-export const dateInRange = (start: string, filterType: string): boolean => {
+export const dateInRange = (start: string, filterType: FilterType): boolean => {
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
   const startDate = new Date(start);
   return (

--- a/frontend/src/utils/DateUtils.ts
+++ b/frontend/src/utils/DateUtils.ts
@@ -8,3 +8,14 @@ export const formatDateString = (dateStringInput: Date): string => {
     timeZone: "UTC",
   });
 };
+
+export const formatDateStringWithYear = (dateStringInput: Date): string => {
+  const date = new Date(dateStringInput); 
+  return date.toLocaleDateString('en-US', {
+    weekday: "long",
+    month: "short",
+    day: "2-digit",
+    year: 'numeric',
+    timeZone: "UTC",
+  })
+}

--- a/frontend/src/utils/DateUtils.ts
+++ b/frontend/src/utils/DateUtils.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
-export const formatDateString = (dateStringInput: Date): string => {
+export const formatDateString = (dateStringInput: string): string => {
   const date = new Date(dateStringInput);
   return date.toLocaleDateString([], {
     weekday: "long",
@@ -9,7 +9,7 @@ export const formatDateString = (dateStringInput: Date): string => {
   });
 };
 
-export const formatDateStringWithYear = (dateStringInput: Date): string => {
+export const formatDateStringWithYear = (dateStringInput: string): string => {
   const date = new Date(dateStringInput);
   return date.toLocaleDateString("en-US", {
     weekday: "long",
@@ -18,4 +18,15 @@ export const formatDateStringWithYear = (dateStringInput: Date): string => {
     year: "numeric",
     timeZone: "UTC",
   });
+};
+
+// currently only supports filter by week and month
+export const dateInRange = (start: string, filterType: string): boolean => {
+  const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+  const startDate = new Date(start);
+  return (
+    startDate.getTime() - Date.now() >= 0 &&
+    startDate.getTime() - Date.now() <
+      (filterType === "week" ? MS_PER_WEEK : MS_PER_WEEK * 4)
+  );
 };

--- a/frontend/src/utils/DateUtils.ts
+++ b/frontend/src/utils/DateUtils.ts
@@ -10,12 +10,12 @@ export const formatDateString = (dateStringInput: Date): string => {
 };
 
 export const formatDateStringWithYear = (dateStringInput: Date): string => {
-  const date = new Date(dateStringInput); 
-  return date.toLocaleDateString('en-US', {
+  const date = new Date(dateStringInput);
+  return date.toLocaleDateString("en-US", {
     weekday: "long",
     month: "short",
     day: "2-digit",
-    year: 'numeric',
+    year: "numeric",
     timeZone: "UTC",
-  })
-}
+  });
+};


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #82 #83 #117


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- refactor posting card according to comments on PR
- created a page that displays events and regular volunteer opportunities (/volunteer/postings), fetches data via a graphQL query
- created an empty event component to display in the case where there are no active events / regular volunteer opportunities
- create filter feature for week/month/all shifts timeframes



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
Navigate to http://localhost:5000/graphql and run the mutation (see: https://github.com/uwblueprint/sistering/pull/140) multiple times with different startDates 
Navigate to http://localhost:3000/volunteer/postings and verify: 
- API call receives the correct data
- Implementation UI matches Figma for #83 Volunteer Browse Postings Page
- Verify the definition of what an volunteer opportunity/event is (line 154 in volunteerPostingsPage.tsx)
- ensure filter functionality works with their timeframe


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
- Implementation UI matches Figma for #83 Volunteer Browse Postings Page
- ensure filter functionality works with their timeframe


## Checklist
- [ x] My PR name is descriptive and in imperative tense
- [ x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x ] I have run the appropriate linter(s)
- [x ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
