### PR TITLE
Add Support for Nested Fields in isAuthorizedByUserId for Retrieving UserId

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -56,7 +56,7 @@ const isValidDateTime = (dateTimeString: string) => {
   return (
     !Number.isNaN(Date.parse(`${dateTimeString}:00`)) && // cover cases of DD > 31
     new Date(`${dateTimeString}:00+00:00`).toISOString().slice(0, 16) ===
-    dateTimeString
+      dateTimeString
   );
 };
 

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -3,7 +3,11 @@ import { GraphQLScalarType, Kind } from "graphql";
 import { applyMiddleware } from "graphql-middleware";
 import { merge } from "lodash";
 
-import { isAuthorizedByRole, isAuthorizedByUserId } from "../middlewares/auth";
+import {
+  isAuthorizedByRole,
+  isAuthorizedByUserId,
+  isAuthorizedByUserIdCreateShiftSignups,
+} from "../middlewares/auth";
 import authResolvers from "./resolvers/authResolvers";
 import authType from "./types/authType";
 import entityResolvers from "./resolvers/entityResolvers";
@@ -175,7 +179,7 @@ const graphQLMiddlewares = {
     updateEmployeeUserById: authorizedByAdminAndEmployee(),
     deleteEmployeeUserById: authorizedByAdmin(),
     deleteEmployeeUserByEmail: authorizedByAdmin(),
-    logout: isAuthorizedByUserId(["userId"]),
+    logout: isAuthorizedByUserId("userId"),
     createShifts: authorizedByAdmin(),
     updateShift: authorizedByAdmin(),
     updateShifts: authorizedByAdmin(),
@@ -192,9 +196,9 @@ const graphQLMiddlewares = {
     deleteBranch: authorizedByAdmin(),
     createShiftSignups:
       authorizedByVolunteer() &&
-      isAuthorizedByUserId(["shifts", "0", "userId"]),
+      isAuthorizedByUserIdCreateShiftSignups("userId"),
     updateShiftSignup:
-      authorizedByAdminAndVolunteer() && isAuthorizedByUserId(["userId"]),
+      authorizedByAdminAndVolunteer() && isAuthorizedByUserId("userId"),
   },
 };
 

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -51,7 +51,7 @@ const isValidDateTime = (dateTimeString: string) => {
   return (
     !Number.isNaN(Date.parse(`${dateTimeString}:00`)) && // cover cases of DD > 31
     new Date(`${dateTimeString}:00+00:00`).toISOString().slice(0, 16) ===
-      dateTimeString
+    dateTimeString
   );
 };
 
@@ -175,7 +175,7 @@ const graphQLMiddlewares = {
     updateEmployeeUserById: authorizedByAdminAndEmployee(),
     deleteEmployeeUserById: authorizedByAdmin(),
     deleteEmployeeUserByEmail: authorizedByAdmin(),
-    logout: isAuthorizedByUserId("userId"),
+    logout: isAuthorizedByUserId(["userId"]),
     createShifts: authorizedByAdmin(),
     updateShift: authorizedByAdmin(),
     updateShifts: authorizedByAdmin(),
@@ -190,8 +190,8 @@ const graphQLMiddlewares = {
     createBranch: authorizedByAdmin(),
     updateBranch: authorizedByAdmin(),
     deleteBranch: authorizedByAdmin(),
-    createShiftSignups: authorizedByVolunteer(),
-    updateShiftSignup: authorizedByAdmin(),
+    createShiftSignups: authorizedByVolunteer() && isAuthorizedByUserId(["shifts", "0", "userId"]),
+    updateShiftSignup: authorizedByAdminAndVolunteer() && isAuthorizedByUserId(["userId"]),
   },
 };
 

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -6,7 +6,8 @@ import { merge } from "lodash";
 import {
   isAuthorizedByRole,
   isAuthorizedByUserId,
-  isAuthorizedByUserIdCreateShiftSignups,
+  isAuthorizedForCreateShiftSignups,
+  isAuthorizedForUpdateShiftSignups,
 } from "../middlewares/auth";
 import authResolvers from "./resolvers/authResolvers";
 import authType from "./types/authType";
@@ -55,7 +56,7 @@ const isValidDateTime = (dateTimeString: string) => {
   return (
     !Number.isNaN(Date.parse(`${dateTimeString}:00`)) && // cover cases of DD > 31
     new Date(`${dateTimeString}:00+00:00`).toISOString().slice(0, 16) ===
-      dateTimeString
+    dateTimeString
   );
 };
 
@@ -136,7 +137,6 @@ const authorizedByAllRoles = () =>
 const authorizedByAdmin = () => isAuthorizedByRole(new Set(["ADMIN"]));
 const authorizedByAdminAndVolunteer = () =>
   isAuthorizedByRole(new Set(["ADMIN", "VOLUNTEER"]));
-const authorizedByVolunteer = () => isAuthorizedByRole(new Set(["VOLUNTEER"]));
 const authorizedByAdminAndEmployee = () =>
   isAuthorizedByRole(new Set(["ADMIN", "EMPLOYEE"]));
 
@@ -194,11 +194,8 @@ const graphQLMiddlewares = {
     createBranch: authorizedByAdmin(),
     updateBranch: authorizedByAdmin(),
     deleteBranch: authorizedByAdmin(),
-    createShiftSignups:
-      authorizedByVolunteer() &&
-      isAuthorizedByUserIdCreateShiftSignups("userId"),
-    updateShiftSignup:
-      authorizedByAdminAndVolunteer() && isAuthorizedByUserId("userId"),
+    createShiftSignups: isAuthorizedForCreateShiftSignups("userId"),
+    updateShiftSignup: isAuthorizedForUpdateShiftSignups("userId"),
   },
 };
 

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -51,7 +51,7 @@ const isValidDateTime = (dateTimeString: string) => {
   return (
     !Number.isNaN(Date.parse(`${dateTimeString}:00`)) && // cover cases of DD > 31
     new Date(`${dateTimeString}:00+00:00`).toISOString().slice(0, 16) ===
-    dateTimeString
+      dateTimeString
   );
 };
 
@@ -190,8 +190,11 @@ const graphQLMiddlewares = {
     createBranch: authorizedByAdmin(),
     updateBranch: authorizedByAdmin(),
     deleteBranch: authorizedByAdmin(),
-    createShiftSignups: authorizedByVolunteer() && isAuthorizedByUserId(["shifts", "0", "userId"]),
-    updateShiftSignup: authorizedByAdminAndVolunteer() && isAuthorizedByUserId(["userId"]),
+    createShiftSignups:
+      authorizedByVolunteer() &&
+      isAuthorizedByUserId(["shifts", "0", "userId"]),
+    updateShiftSignup:
+      authorizedByAdminAndVolunteer() && isAuthorizedByUserId(["userId"]),
   },
 };
 

--- a/backend/middlewares/auth.ts
+++ b/backend/middlewares/auth.ts
@@ -52,8 +52,12 @@ export const isAuthorizedByRole = (roles: Set<Role>) => {
 
 /* Determine if request for a user-specific resource is authorized based on accessToken
  * validity and if the userId that the token was issued to matches the requested userId
- * Note: userIdField is the name of the request parameter containing the requested userId */
-export const isAuthorizedByUserId = (userIdField: string) => {
+ * Note: userIdPath is a list of keys to traverse through the args object to get to
+ * access the requested userId
+ * For example, if args is { shifts: [ { userId: <ID> } ] }, then a userIdPath of
+ * ["shifts", "0", "userId"] would retrieve the <ID> from the args object
+ *  */
+export const isAuthorizedByUserId = (userIdPath: string[]) => {
   return async (
     resolve: (
       parent: any,
@@ -67,9 +71,10 @@ export const isAuthorizedByUserId = (userIdField: string) => {
     info: GraphQLResolveInfo,
   ): Promise<any> => {
     const accessToken = getAccessToken(context.req);
+    const userId: any = userIdPath.reduce((acc, curr) => acc[curr], args);
     const authorized =
       accessToken &&
-      (await authService.isAuthorizedByUserId(accessToken, args[userIdField]));
+      (await authService.isAuthorizedByUserId(accessToken, userId));
 
     if (!authorized) {
       throw new AuthenticationError(


### PR DESCRIPTION
## Ticket link
Closes #115


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created `isAuthorizedForCreateShiftSignups` check for `createShiftSignups` and `isAuthorizedForUpdateShiftSignups` check for `updateShiftSignup`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Ensure that your local db contains the [seed data
](https://uwblueprint.slack.com/archives/C02CN0ZAZDG/p1645395343075529)
2. `docker-compose up --build`
3. Navigate to http://localhost:5000/graphql 
4. Run the following mutations and ensure the results are expected (Credits for the mutations to Joseph from #90 🙏).

Sign in as a volunteer and use the access token for the following mutations:
```graphql
# Create Shift Signups
mutation {
  createShiftSignups(
    shifts: [{ shiftId: 2, userId: 1, numVolunteers: 3, note: "test" }]
  ) {
    shiftId
    userId
    numVolunteers
    note
  }
}
# Expected result: error with "Failed authentication and/or authorization by userId"

mutation {
  createShiftSignups(
    shifts: [{ shiftId: 2, userId: 2, numVolunteers: 3, note: "test" }]
  ) {
    shiftId
    userId
    numVolunteers
    note
  }
}
# Expected result: succeed

# Update Shift Signup
mutation {
  updateShiftSignup(
    shiftId: "2"
    userId: "1"
    update: { status: CONFIRMED, note: "test", numVolunteers: 3 }
  ) {
    shiftId
    userId
    numVolunteers
    note
    status
  }
}
# Expected result: error with "Failed authentication and/or authorization by userId"

mutation {
  updateShiftSignup(
    shiftId: "2"
    userId: "2"
    update: { status: CONFIRMED, note: "test", numVolunteers: 3 }
  ) {
    shiftId
    userId
    numVolunteers
    note
    status
  }
}
# Expected result: succeed
```
Sign in as an admin and use the access token for the following mutations:
```graphql
# Create Shift Signups
mutation {
  createShiftSignups(
    shifts: [{ shiftId: 2, userId: 1, numVolunteers: 3, note: "test" }]
  ) {
    shiftId
    userId
    numVolunteers
    note
  }
}
# Expected result: error with "Failed authentication and/or authorization by userId"

# Update Shift Signup
mutation {
  updateShiftSignup(
    shiftId: "2"
    userId: "2"
    update: { status: CONFIRMED, note: "test", numVolunteers: 3 }
  ) {
    shiftId
    userId
    numVolunteers
    note
    status
  }
}
# Expected result: succeed
```

Sign in as an employee and use the access token for the following mutations:
```graphql
# Create Shift Signups
mutation {
  createShiftSignups(
    shifts: [{ shiftId: 2, userId: 3, numVolunteers: 3, note: "test" }]
  ) {
    shiftId
    userId
    numVolunteers
    note
  }
}
# Expected result: error with "Failed authentication and/or authorization by userId"

# Update Shift Signup
mutation {
  updateShiftSignup(
    shiftId: "2"
    userId: "3"
    update: { status: CONFIRMED, note: "test", numVolunteers: 3 }
  ) {
    shiftId
    userId
    numVolunteers
    note
    status
  }
}
# Expected result: error with "Failed authentication and/or authorization by userId"
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensuring that the mutations above produce the expected result

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
