### PR TITLE
Redirect to 404 page when posting does not exist

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -167,6 +167,11 @@ const App = (): React.ReactElement => {
                       path={Routes.ADMIN_POSTING_DETAILS}
                       component={AdminPostingDetails}
                     />
+                    <PrivateRoute
+                      exact
+                      path={Routes.NOT_FOUND_PAGE}
+                      component={NotFound}
+                    />
                     <Route exact path="*" component={NotFound} />
                   </Switch>
                 </Router>

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from "react";
+import React from "react";
 import { VStack, HStack, Box, Container, Button } from "@chakra-ui/react";
 
 import { gql, useQuery } from "@apollo/client";
-import { useParams } from "react-router-dom";
+import { useParams, Redirect } from "react-router-dom";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
-import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import PostingDetails from "../../../common/PostingDetails";
 
 const POSTING = gql`
@@ -31,18 +30,17 @@ const POSTING = gql`
 
 const VolunteerPostingDetails = (): React.ReactElement => {
   const { id } = useParams<{ id: string }>();
-  const [
-    postingDetails,
-    setPostingDetails,
-  ] = useState<PostingResponseDTO | null>(null);
-  useQuery(POSTING, {
-    variables: { id },
-    fetchPolicy: "cache-and-network",
-    onCompleted: (data) => {
-      setPostingDetails(data.posting);
+  const { loading, data: { posting: postingDetails } = {} } = useQuery(
+    POSTING,
+    {
+      variables: { id },
+      fetchPolicy: "cache-and-network",
     },
-  });
-  return (
+  );
+
+  return !loading && !postingDetails ? (
+    <Redirect to="/not-found" />
+  ) : (
     <Box bg="background.light" py={7} px={10} minH="100vh">
       <VStack>
         <Container pt={0} pb={4} px={0} maxW="container.xl">

--- a/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
+++ b/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
@@ -1,19 +1,12 @@
 import React from "react";
 import { Box, Text } from "@chakra-ui/react";
 import VolunteerNavbar from "../../../volunteer/VolunteerNavbar";
-<<<<<<< HEAD
 import { VolunteerPages } from "../../../../constants/Volunteer";
-=======
->>>>>>> Create VolunteerNavbar
 
 const VolunteerShiftsPage = (): React.ReactElement => {
   return (
     <div>
-<<<<<<< HEAD
       <VolunteerNavbar defaultIndex={VolunteerPages.VolunteerShiftsPage} />
-=======
-      <VolunteerNavbar defaultIndex={0} />
->>>>>>> Create VolunteerNavbar
       <Box bg="background.light">
         <Text textStyle="display-large">Volunteer Shifts</Text>
       </Box>

--- a/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
+++ b/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
@@ -1,12 +1,19 @@
 import React from "react";
 import { Box, Text } from "@chakra-ui/react";
 import VolunteerNavbar from "../../../volunteer/VolunteerNavbar";
+<<<<<<< HEAD
 import { VolunteerPages } from "../../../../constants/Volunteer";
+=======
+>>>>>>> Create VolunteerNavbar
 
 const VolunteerShiftsPage = (): React.ReactElement => {
   return (
     <div>
+<<<<<<< HEAD
       <VolunteerNavbar defaultIndex={VolunteerPages.VolunteerShiftsPage} />
+=======
+      <VolunteerNavbar defaultIndex={0} />
+>>>>>>> Create VolunteerNavbar
       <Box bg="background.light">
         <Text textStyle="display-large">Volunteer Shifts</Text>
       </Box>

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -8,6 +8,8 @@ export const RESET_PASSWORD_PAGE = "/reset-password";
 
 export const DONE_RESET_PASSWORD_PAGE = "/done-reset-password";
 
+export const NOT_FOUND_PAGE = "/not-found";
+
 export const EDIT_TEAM_PAGE = "/edit-team";
 
 export const EDIT_POSTING_PAGE = "/edit-posting";


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #144 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a `/not-found` route for `NotFound.tsx` component
* In `VolunteerPostingDetails.tsx`, redirect to `/not-found` when posting does not exist
  * Note: I had to change the way the `postingDetails` variable was being set when calling `useQuery`, because before, `loading` and `postingDetails` could be `false` **and** `null` at the same time even though the posting exists


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `/volunteer/posting/{id}` and replace id with a posting id you have created in your local database
2. Check that the page still loads when the posting exists
3. Try changing the id to one that does not exist and check that the page redirects to not found


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
