### PR TITLE
Add volunteer select availability table

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -149,6 +149,7 @@ const graphQLMiddlewares = {
     users: authorizedByAdmin(),
     shift: authorizedByAdmin(),
     shifts: authorizedByAdmin(),
+    shiftsByPosting: authorizedByAdmin(),
     posting: authorizedByAdmin(),
     postings: authorizedByAdmin(),
     volunteerUserById: authorizedByAdminAndVolunteer(),

--- a/backend/graphql/resolvers/shiftResolvers.ts
+++ b/backend/graphql/resolvers/shiftResolvers.ts
@@ -19,6 +19,12 @@ const shiftResolvers = {
     shifts: async (): Promise<ShiftResponseDTO[]> => {
       return shiftService.getShifts();
     },
+    shiftsByPosting: async (
+      _parent: undefined,
+      { postingId }: { postingId: string },
+    ): Promise<ShiftResponseDTO[]> => {
+      return shiftService.getShiftsByPosting(postingId);
+    },
   },
   Mutation: {
     createShifts: async (

--- a/backend/graphql/types/shiftType.ts
+++ b/backend/graphql/types/shiftType.ts
@@ -30,6 +30,7 @@ const shiftType = gql`
   extend type Query {
     shift(id: ID!): ShiftResponseDTO!
     shifts: [ShiftResponseDTO!]!
+    shiftsByPosting(postingId: ID!): [ShiftResponseDTO!]!
   }
 
   extend type Mutation {

--- a/backend/services/implementations/shiftService.ts
+++ b/backend/services/implementations/shiftService.ts
@@ -197,6 +197,25 @@ class ShiftService implements IShiftService {
     }
   }
 
+  async getShiftsByPosting(postingId: string): Promise<ShiftResponseDTO[]> {
+    try {
+      const shifts: Array<Shift> = await prisma.shift.findMany({
+        where: {
+          postingId: Number(postingId),
+        },
+      });
+      return shifts.map((shift) => ({
+        id: String(shift.id),
+        postingId: String(shift.postingId),
+        startTime: shift.startTime,
+        endTime: shift.endTime,
+      }));
+    } catch (error) {
+      Logger.error(`Failed to get shifts. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
   async createShift(
     shift: TimeBlock,
     postingId: string,

--- a/backend/services/interfaces/IShiftService.ts
+++ b/backend/services/interfaces/IShiftService.ts
@@ -22,6 +22,14 @@ interface IShiftService {
   getShifts(): Promise<ShiftResponseDTO[]>;
 
   /**
+   * Get all shift information (possibly paginated in the future) of a posting
+   * @param postingId the id of the posting associated with the shifts
+   * @returns array of ShiftDTOs for posting
+   * @throws Error if shift retrieval fails
+   */
+  getShiftsByPosting(postingId: string): Promise<ShiftResponseDTO[]>;
+
+  /**
    * Create a shift
    * @param shift the shift to be created
    * @param postingId the id of the posting associated with the shift

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import customTheme from "./theme";
 import { AuthenticatedUser } from "./types/AuthTypes";
 import VolunteerShiftsPage from "./components/pages/volunteer/shift/VolunteerShiftsPage";
 import AdminSchedulePostingPage from "./components/pages/admin/schedule/AdminSchedulePostingPage";
+import VolunteerPostingAvailabilities from "./components/pages/volunteer/posting/VolunteerPostingAvailabilities";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
@@ -156,6 +157,11 @@ const App = (): React.ReactElement => {
                       exact
                       path={Routes.VOLUNTEER_POSTING_DETAILS}
                       component={VolunteerPostingDetails}
+                    />
+                    <PrivateRoute
+                      exact
+                      path={Routes.VOLUNTEER_POSTING_AVAILABILITIES}
+                      component={VolunteerPostingAvailabilities}
                     />
                     <PrivateRoute
                       exact

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from "react";
+import { Box, Button, Flex, Spacer, Spinner, Text } from "@chakra-ui/react";
+
+import { gql, useQuery } from "@apollo/client";
+import { Redirect, useHistory, useParams } from "react-router-dom";
+import { ChevronLeftIcon } from "@chakra-ui/icons";
+import VolunteerAvailabilityTable from "../../../volunteer/shifts/VolunteerAvailabilityTable";
+import { ShiftResponseDTO } from "../../../../types/api/ShiftTypes";
+import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
+import { SignupRequestDTO } from "../../../../types/api/SignupTypes";
+
+// TODO: A filter should be added to the backend, currently, no filter is supported
+const SHIFTS_BY_POSTING = gql`
+  query VolunteerPostingAvailabilities_ShiftsByPosting($postingId: ID!) {
+    shiftsByPosting(postingId: $postingId) {
+      id
+      postingId
+      startTime
+      endTime
+    }
+  }
+`;
+
+// TODO: Remove redundancy from other pages
+const POSTING = gql`
+  query VolunteerPostingDetails_Posting($id: ID!) {
+    posting(id: $id) {
+      title
+      description
+      branch {
+        name
+      }
+      startDate
+      endDate
+      numVolunteers
+      skills {
+        name
+      }
+      employees {
+        id
+      }
+      autoClosingDate
+    }
+  }
+`;
+
+const VolunteerPostingAvailabilities = (): React.ReactElement => {
+  const { id } = useParams<{ id: string }>();
+  const { loading: isShiftsLoading, data: { shiftsByPosting } = {} } = useQuery(
+    SHIFTS_BY_POSTING,
+    {
+      variables: { postingId: id },
+      fetchPolicy: "cache-and-network",
+    },
+  );
+  const {
+    loading: isPostingLoading,
+    data: { posting: postingDetails } = {},
+  } = useQuery(POSTING, {
+    variables: { id },
+    fetchPolicy: "cache-and-network",
+  });
+  const history = useHistory();
+  // TODO: Use these state of selected shifts + notes for submission
+  const [shiftSignups, setShiftSignups] = useState<ShiftResponseDTO[]>([]);
+  const [signupNotes, setSignupNotes] = useState<SignupRequestDTO[]>([]);
+
+  if (isPostingLoading || isShiftsLoading) {
+    return <Spinner />;
+  }
+
+  return !(isShiftsLoading || isPostingLoading) && !shiftsByPosting ? (
+    <Redirect to="/not-found" />
+  ) : (
+    <Box bg="background.light" pt={14} px={100} minH="100vh">
+      <Button
+        onClick={() => history.push(`/volunteer/posting/${id}`)}
+        variant="link"
+        mb={4}
+        leftIcon={<ChevronLeftIcon />}
+      >
+        Back to posting details
+      </Button>
+      <Flex pb={7}>
+        <Text textStyle="display-large">Select your Availability</Text>
+        <Spacer />
+        <Button
+          onClick={() => {
+            // Submit the selected shifts
+            console.log(shiftSignups);
+            console.log(signupNotes);
+          }}
+        >
+          Submit
+        </Button>
+      </Flex>
+      <VolunteerAvailabilityTable
+        postingShifts={shiftsByPosting as ShiftResponseDTO[]}
+        postingStartDate={
+          new Date(Date.parse((postingDetails as PostingResponseDTO).startDate))
+        }
+        postingEndDate={
+          new Date(Date.parse((postingDetails as PostingResponseDTO).endDate))
+        }
+        selectedShifts={shiftSignups}
+        setSelectedShifts={setShiftSignups}
+        signupNotes={signupNotes}
+        setSignupNotes={setSignupNotes}
+      />
+    </Box>
+  );
+};
+
+export default VolunteerPostingAvailabilities;

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useLayoutEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
-import { Text, Box, HStack, Select } from "@chakra-ui/react";
+import { Box, HStack, Select, Text } from "@chakra-ui/react";
 
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import { dateInRange } from "../../../../utils/DateTimeUtils";
 import { FilterType } from "../../../../types/DateFilterTypes";
-import PostingCard from "../../../volunteer/PostingCard";
 import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
+import PostingCard from "../../../volunteer/PostingCard";
 import VolunteerNavbar from "../../../volunteer/VolunteerNavbar";
 
 type Posting = Omit<

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
@@ -1,0 +1,108 @@
+import { Table, Tbody, Td, Text, Tr } from "@chakra-ui/react";
+import React from "react";
+import moment from "moment";
+import NoShiftsAvailableTableRow from "./NoShiftsAvailableTableRow";
+import VolunteerAvailabilityTableRow from "./VolunteerAvailabilityTableRow";
+
+type VolunteerAvailabilityTableProps = { postingId: number };
+
+// Temp type
+type Shift = {
+  startTime: Date;
+  endTime: Date;
+};
+
+const VolunteerAvailabilityTable = ({
+  postingId,
+}: VolunteerAvailabilityTableProps): React.ReactElement => {
+  // Side note: I think we should try to avoid doing queries in table components when avbailable03
+  // Query to get some posting
+
+  // Sample data
+  const current = new Date();
+  const postingStartWeek = new Date(
+    current.setDate(current.getDate() - current.getDay()),
+  );
+  const postingShifts: Shift[] = [
+    {
+      startTime: new Date(),
+      endTime: new Date(Date.now() + 2.25 * 1000 * 60 * 60),
+    },
+    {
+      startTime: new Date(Date.now() + 3 * 1000 * 60 * 60),
+      endTime: new Date(Date.now() + 4 * 1000 * 60 * 60),
+    },
+    {
+      startTime: new Date(
+        new Date(Date.now() + 2 * 1000 * 60 * 60).setDate(
+          new Date().getDate() + 1,
+        ),
+      ),
+      endTime: new Date(
+        new Date(Date.now() + 2.5 * 1000 * 60 * 60).setDate(
+          new Date().getDate() + 1,
+        ),
+      ),
+    },
+  ];
+
+  const [currentWeek, setWeek] = React.useState(postingStartWeek);
+  const [shifts, setShifts] = React.useState(postingShifts);
+
+  return (
+    <Table variant="striped" colorScheme="teal" w="100%">
+      {Array.from(Array(7).keys()).map((day) => {
+        const date = new Date(
+          new Date(currentWeek).setDate(currentWeek.getDate() + day),
+        );
+
+        return (
+          <Tbody key={day}>
+            <Tr>
+              <Td bgColor="background.light">
+                <Text textStyle="body-bold">
+                  {date.toLocaleDateString("en-US", {
+                    weekday: "long",
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </Text>
+              </Td>
+            </Tr>
+            {shifts.filter(
+              (shift) =>
+                moment(shift.startTime).diff(date, "days", false) === 0,
+            ).length < 1 ? (
+              <Tr>
+                <Td>
+                  <NoShiftsAvailableTableRow />
+                </Td>
+              </Tr>
+            ) : (
+              shifts
+                .filter(
+                  (shift) =>
+                    moment(shift.startTime).diff(date, "days", false) === 0,
+                )
+                .map((shift, index) => {
+                  return (
+                    <Tr key={`${day}-${index}`}>
+                      <Td p={0}>
+                        <VolunteerAvailabilityTableRow
+                          start={shift.startTime}
+                          end={shift.endTime}
+                        />
+                      </Td>
+                    </Tr>
+                  );
+                })
+            )}
+          </Tbody>
+        );
+      })}
+    </Table>
+  );
+};
+
+export default VolunteerAvailabilityTable;

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
@@ -19,22 +19,30 @@ const VolunteerAvailabilityTableRow = ({
   end,
 }: VolunteerAvailabilityTableRowProps): React.ReactElement => {
   const [note, setNote] = React.useState("");
+  const [checked, setChecked] = React.useState(false);
 
   return (
     <Flex>
-      <Checkbox minWidth={300} mr={170}>
+      <Checkbox
+        minWidth={300}
+        mr={170}
+        checked={checked}
+        onChange={(event) => setChecked(event.target.checked)}
+      >
         {`${formatTimeHourMinutes(start)} -  ${formatTimeHourMinutes(
           end,
         )} (${getElapsedHours(start, end)} hrs)`}
       </Checkbox>
       <InputGroup>
         <Input
+          isDisabled={!checked}
+          bg="white"
           placeholder="Add note (optional)"
           value={note}
           onChange={(event) => setNote(event.target.value)}
         />
         <InputRightElement
-          visibility={note.trim().length > 0 ? "visible" : "hidden"}
+          visibility={note.trim().length > 0 && checked ? "visible" : "hidden"}
         >
           <CheckIcon color="brand.500" />
         </InputRightElement>

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
@@ -22,7 +22,7 @@ const VolunteerAvailabilityTableRow = ({
   const [checked, setChecked] = React.useState(false);
 
   return (
-    <Flex>
+    <Flex bgColor={checked ? "purple.50" : undefined} px={25} py={3}>
       <Checkbox
         minWidth={300}
         mr={170}

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
@@ -11,23 +11,52 @@ import {
   formatTimeHourMinutes,
   getElapsedHours,
 } from "../../../utils/DateTimeUtils";
+import { ShiftResponseDTO } from "../../../types/api/ShiftTypes";
+import { SignupRequestDTO } from "../../../types/api/SignupTypes";
 
-type VolunteerAvailabilityTableRowProps = { start: Date; end: Date };
+type VolunteerAvailabilityTableRowProps = {
+  shift: ShiftResponseDTO;
+  selectedShifts: ShiftResponseDTO[];
+  setSelectedShifts: React.Dispatch<React.SetStateAction<ShiftResponseDTO[]>>;
+  signupNotes: SignupRequestDTO[];
+  setSignupNotes: React.Dispatch<React.SetStateAction<SignupRequestDTO[]>>;
+  start: Date;
+  end: Date;
+};
 
 const VolunteerAvailabilityTableRow = ({
+  shift,
+  selectedShifts,
+  setSelectedShifts,
+  signupNotes,
+  setSignupNotes,
   start,
   end,
 }: VolunteerAvailabilityTableRowProps): React.ReactElement => {
-  const [note, setNote] = React.useState("");
-  const [checked, setChecked] = React.useState(false);
+  const [checked, setChecked] = React.useState(selectedShifts.includes(shift));
+  const signupNote = React.useMemo(() => {
+    const note = signupNotes.find((s) => s.shiftId === shift.id);
+    if (note) {
+      return note.note;
+    }
+    return "";
+  }, [signupNotes, shift]);
 
   return (
     <Flex bgColor={checked ? "purple.50" : undefined} px={25} py={3}>
       <Checkbox
         minWidth={300}
         mr={170}
-        checked={checked}
-        onChange={(event) => setChecked(event.target.checked)}
+        isChecked={checked}
+        onChange={(event) => {
+          if (!checked) {
+            setSelectedShifts([...selectedShifts, shift]);
+          } else {
+            const selected = selectedShifts.filter((s) => s !== shift);
+            setSelectedShifts(selected);
+          }
+          setChecked(event.target.checked);
+        }}
       >
         {`${formatTimeHourMinutes(start)} -  ${formatTimeHourMinutes(
           end,
@@ -38,11 +67,21 @@ const VolunteerAvailabilityTableRow = ({
           isDisabled={!checked}
           bg="white"
           placeholder="Add note (optional)"
-          value={note}
-          onChange={(event) => setNote(event.target.value)}
+          onChange={(event) => {
+            const otherNotes = signupNotes.filter(
+              (s) => s.shiftId !== shift.id,
+            );
+            setSignupNotes([
+              ...otherNotes,
+              {
+                shiftId: shift.id,
+                note: event.target.value.toString().trim(),
+              },
+            ]);
+          }}
         />
         <InputRightElement
-          visibility={note.trim().length > 0 && checked ? "visible" : "hidden"}
+          visibility={signupNote.length > 0 && checked ? "visible" : "hidden"}
         >
           <CheckIcon color="brand.500" />
         </InputRightElement>

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -36,3 +36,6 @@ export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
 export const ADMIN_POSTING_DETAILS = "/admin/posting/:id";
 
 export const ADMIN_SCHEDULE_POSTING_PAGE = "/admin/schedule/posting/:id";
+
+export const VOLUNTEER_POSTING_AVAILABILITIES =
+  "/volunteer/posting/:id/availabilities";

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -92,6 +92,40 @@ const customTheme = extendTheme(
           },
         },
       },
+      Table: {
+        variants: {
+          brand: {
+            table: {
+              border: "2px",
+              borderSpacing: "0",
+              borderColor: "background.dark",
+              overflow: "hidden",
+            },
+            th: {
+              ...textStyles["body-regular"],
+              fontWeight: "bold",
+              textTransform: "inherit",
+              letterSpacing: "inherit",
+              backgroundColor: "background.light",
+              borderBottom: "2px",
+              borderColor: "background.dark",
+              borderCollapse: "collapse",
+            },
+            td: {
+              borderBottom: "2px",
+              borderColor: "background.dark",
+              borderCollapse: "collapse",
+            },
+            tr: {
+              _last: {
+                td: {
+                  borderBottom: "none",
+                },
+              },
+            },
+          },
+        },
+      },
     },
   },
   withDefaultColorScheme({ colorScheme: "brand" }),

--- a/frontend/src/types/api/SignupTypes.ts
+++ b/frontend/src/types/api/SignupTypes.ts
@@ -1,0 +1,14 @@
+export type SignupDTO = {
+  id: string;
+  shiftId: string;
+  userId: string;
+  numVolunteers: number;
+  note: string;
+};
+
+export type SignupRequestDTO = Omit<
+  SignupDTO,
+  "id" | "numVolunteers" | "userId"
+>;
+
+export type SignupResponseDTO = SignupDTO;

--- a/frontend/src/utils/DateTimeUtils.ts
+++ b/frontend/src/utils/DateTimeUtils.ts
@@ -102,3 +102,25 @@ export const getUTCDateForDateTimeString = (dateTimeString: string): Date => {
   // using ISO 8601 date-time form with timezone specifier
   return new Date(`${dateTimeString}:00+00:00`);
 };
+
+/**
+ * get integer difference of days between 2 dates (end - start)
+ * @param  {Date} start
+ * @param  {Date} end
+ * @returns number
+ */
+export const getDayDiff = (start: Date, end: Date): number => {
+  return moment(end).diff(start, "days", false);
+};
+
+/**
+ * get integer difference of weeks between 2 dates (end - start)
+ * @param  {Date} start
+ * @param  {Date} end
+ * @returns number
+ */
+export const getWeekDiff = (start: Date, end: Date): number => {
+  return moment(end)
+    .startOf("week")
+    .diff(moment(start).startOf("week").toDate(), "week", false);
+};


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #120, #119, #129


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
![image](https://user-images.githubusercontent.com/44826218/154866250-2766286d-199d-4782-8ec6-21e56254f9ba.png)

* Add volunteer select availability table
* Enhanced base components for better padding, highlighted background on select, disabled input when not selected

TODO:
- change prop type from postingId to posting type (@uwblueprint/sistering-w22-pls  I'm not sure what type I should use here). This can honestly be done in the integration step
 
<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Play around with the test page on the `volunteer/posting` route
2. input should be disabled if shift checkbox is not selected
3. background should highlight when shift selected
4. page should display current week from sun to sat correctly with appropriate shifts in each table section

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Design: look and feel
* Dev: Implementation of table

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
