### PR TITLE
Volunteer select availability table datafetch newpage

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -145,6 +145,7 @@ const graphQLMiddlewares = {
     users: authorizedByAdmin(),
     shift: authorizedByAdmin(),
     shifts: authorizedByAdmin(),
+    shiftsByPosting: authorizedByAdmin(),
     posting: authorizedByAdmin(),
     postings: authorizedByAdmin(),
     volunteerUserById: authorizedByAdminAndVolunteer(),

--- a/backend/graphql/resolvers/shiftResolvers.ts
+++ b/backend/graphql/resolvers/shiftResolvers.ts
@@ -19,6 +19,12 @@ const shiftResolvers = {
     shifts: async (): Promise<ShiftResponseDTO[]> => {
       return shiftService.getShifts();
     },
+    shiftsByPosting: async (
+      _parent: undefined,
+      { postingId }: { postingId: string },
+    ): Promise<ShiftResponseDTO[]> => {
+      return shiftService.getShiftsByPosting(postingId);
+    },
   },
   Mutation: {
     createShifts: async (

--- a/backend/graphql/types/shiftType.ts
+++ b/backend/graphql/types/shiftType.ts
@@ -30,6 +30,7 @@ const shiftType = gql`
   extend type Query {
     shift(id: ID!): ShiftResponseDTO!
     shifts: [ShiftResponseDTO!]!
+    shiftsByPosting(postingId: ID!): [ShiftResponseDTO!]!
   }
 
   extend type Mutation {

--- a/backend/services/implementations/shiftService.ts
+++ b/backend/services/implementations/shiftService.ts
@@ -197,6 +197,25 @@ class ShiftService implements IShiftService {
     }
   }
 
+  async getShiftsByPosting(postingId: string): Promise<ShiftResponseDTO[]> {
+    try {
+      const shifts: Array<Shift> = await prisma.shift.findMany({
+        where: {
+          postingId: Number(postingId),
+        },
+      });
+      return shifts.map((shift) => ({
+        id: String(shift.id),
+        postingId: String(shift.postingId),
+        startTime: shift.startTime,
+        endTime: shift.endTime,
+      }));
+    } catch (error) {
+      Logger.error(`Failed to get shifts. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
   async createShift(
     shift: TimeBlock,
     postingId: string,

--- a/backend/services/interfaces/IShiftService.ts
+++ b/backend/services/interfaces/IShiftService.ts
@@ -22,6 +22,14 @@ interface IShiftService {
   getShifts(): Promise<ShiftResponseDTO[]>;
 
   /**
+   * Get all shift information (possibly paginated in the future) of a posting
+   * @param postingId the id of the posting associated with the shifts
+   * @returns array of ShiftDTOs for posting
+   * @throws Error if shift retrieval fails
+   */
+  getShiftsByPosting(postingId: string): Promise<ShiftResponseDTO[]>;
+
+  /**
    * Create a shift
    * @param shift the shift to be created
    * @param postingId the id of the posting associated with the shift

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import SideNavbarDemo from "./components/pages/SideNavbarDemo";
 import customTheme from "./theme";
 import { AuthenticatedUser } from "./types/AuthTypes";
 import VolunteerShiftsPage from "./components/pages/volunteer/shift/VolunteerShiftsPage";
+import VolunteerPostingAvailabilities from "./components/pages/volunteer/posting/VolunteerPostingAvailabilities";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
@@ -161,6 +162,11 @@ const App = (): React.ReactElement => {
                       exact
                       path={Routes.VOLUNTEER_POSTING_DETAILS}
                       component={VolunteerPostingDetails}
+                    />
+                    <PrivateRoute
+                      exact
+                      path={Routes.VOLUNTEER_POSTING_AVAILABILITIES}
+                      component={VolunteerPostingAvailabilities}
                     />
                     <PrivateRoute
                       exact

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { Spinner, Text } from "@chakra-ui/react";
+import React, { useState } from "react";
+import { Box, Button, Flex, Spacer, Spinner, Text } from "@chakra-ui/react";
 
 import { gql, useQuery } from "@apollo/client";
-import { useParams } from "react-router-dom";
+import { Redirect, useHistory, useParams } from "react-router-dom";
+import { ChevronLeftIcon } from "@chakra-ui/icons";
 import VolunteerAvailabilityTable from "../../../volunteer/shifts/VolunteerAvailabilityTable";
-import { ShiftResponseDTO } from "../../../../types/api/ShiftTypes";
+import { ShiftDTO, ShiftResponseDTO } from "../../../../types/api/ShiftTypes";
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 
 // TODO: A filter should be added to the backend, currently, no filter is supported
@@ -42,13 +43,8 @@ const POSTING = gql`
   }
 `;
 
-// TODO: Get posting for posting start and end time
-
 const VolunteerPostingAvailabilities = (): React.ReactElement => {
-  // posting id
   const { id } = useParams<{ id: string }>();
-  // eslint-disable-next-line no-console
-  console.log(id);
   const { loading: isShiftsLoading, data: { shifts } = {} } = useQuery(SHIFTS, {
     fetchPolicy: "cache-and-network",
   });
@@ -59,60 +55,38 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
     variables: { id },
     fetchPolicy: "cache-and-network",
   });
-
-  console.log(shifts);
-
-  // Sample data
-  const postingShifts: ShiftResponseDTO[] = [
-    {
-      id: "1",
-      postingId: "1",
-      startTime: new Date(),
-      endTime: new Date(Date.now() + 2.25 * 1000 * 60 * 60),
-    },
-    {
-      id: "1",
-      postingId: "1",
-      startTime: new Date(Date.now() + 3 * 1000 * 60 * 60),
-      endTime: new Date(Date.now() + 4 * 1000 * 60 * 60),
-    },
-    {
-      id: "1",
-      postingId: "1",
-      startTime: new Date(
-        new Date(Date.now() + 2 * 1000 * 60 * 60).setDate(
-          new Date().getDate() + 1,
-        ),
-      ),
-      endTime: new Date(
-        new Date(Date.now() + 2.5 * 1000 * 60 * 60).setDate(
-          new Date().getDate() + 1,
-        ),
-      ),
-    },
-  ];
-
-  const postingStartDate = new Date(
-    new Date().setDate(new Date().getDate() - 14),
-  );
-
-  const postingEndDate = new Date(
-    new Date().setDate(new Date().getDate() + 14),
-  );
-  // End of sample data
+  const history = useHistory();
+  // TODO: Use this state of selected shifts for submission
+  const [selectedShifts, setSelectedShifts] = useState<ShiftDTO[]>([]);
 
   if (isPostingLoading || isShiftsLoading) {
     return <Spinner />;
   }
 
-  return (
-    <div>
-      <Text textStyle="display-large">Volunteer Postings</Text>
-      {/* <VolunteerAvailabilityTable
-        postingShifts={postingShifts}
-        postingStartDate={postingStartDate}
-        postingEndDate={postingEndDate}
-      /> */}
+  return !(isShiftsLoading || isPostingLoading) && !shifts ? (
+    <Redirect to="/not-found" />
+  ) : (
+    <Box bg="background.light" pt={14} px={100} minH="100vh">
+      <Button
+        onClick={() => history.push(`/volunteer/posting/${id}`)}
+        variant="link"
+        mb={4}
+        leftIcon={<ChevronLeftIcon />}
+      >
+        Back to posting details
+      </Button>
+      <Flex pb={7}>
+        <Text textStyle="display-large">Select your Availability</Text>
+        <Spacer />
+        <Button
+          onClick={() => {
+            // Submit the selected shifts
+            console.log(selectedShifts);
+          }}
+        >
+          Submit
+        </Button>
+      </Flex>
       <VolunteerAvailabilityTable
         postingShifts={(shifts as ShiftResponseDTO[]).filter(
           (shift) => shift.postingId === id,
@@ -123,17 +97,11 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
         postingEndDate={
           new Date(Date.parse((postingDetails as PostingResponseDTO).endDate))
         }
+        selectedShifts={selectedShifts}
+        setSelectedShifts={setSelectedShifts}
       />
-    </div>
+    </Box>
   );
-  //   return !loading && !shifts ? (
-  //     <Redirect to="/not-found" />
-  //   ) : (
-  //     <div>
-  //       <Text textStyle="display-large">Volunteer Postings</Text>
-  //       <VolunteerAvailabilityTable postingShifts={postingShifts} />
-  //     </div>
-  //   );
 };
 
 export default VolunteerPostingAvailabilities;

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Spinner, Text } from "@chakra-ui/react";
+
+import { gql, useQuery } from "@apollo/client";
+import { useParams } from "react-router-dom";
+import VolunteerAvailabilityTable from "../../../volunteer/shifts/VolunteerAvailabilityTable";
+import { ShiftResponseDTO } from "../../../../types/api/ShiftTypes";
+
+// TODO: A filter should be added to the backend, currently, no filter is supported
+const SHIFTS = gql`
+  query VolunteerPostingAvailabilities_Shifts {
+    shifts {
+      id
+      postingId
+      startTime
+      endTime
+    }
+  }
+`;
+
+// TODO: Get posting for posting start and end time
+
+const VolunteerPostingAvailabilities = (): React.ReactElement => {
+  // posting id
+  const { id } = useParams<{ id: string }>();
+  // eslint-disable-next-line no-console
+  console.log(id);
+  const { loading, data: { shifts } = {} } = useQuery(SHIFTS, {
+    fetchPolicy: "cache-and-network",
+  });
+  console.log(shifts);
+
+  // Sample data
+  const postingShifts: ShiftResponseDTO[] = [
+    {
+      id: "1",
+      postingId: "1",
+      startTime: new Date(),
+      endTime: new Date(Date.now() + 2.25 * 1000 * 60 * 60),
+    },
+    {
+      id: "1",
+      postingId: "1",
+      startTime: new Date(Date.now() + 3 * 1000 * 60 * 60),
+      endTime: new Date(Date.now() + 4 * 1000 * 60 * 60),
+    },
+    {
+      id: "1",
+      postingId: "1",
+      startTime: new Date(
+        new Date(Date.now() + 2 * 1000 * 60 * 60).setDate(
+          new Date().getDate() + 1,
+        ),
+      ),
+      endTime: new Date(
+        new Date(Date.now() + 2.5 * 1000 * 60 * 60).setDate(
+          new Date().getDate() + 1,
+        ),
+      ),
+    },
+  ];
+
+  const postingStartDate = new Date(
+    new Date().setDate(new Date().getDate() - 14),
+  );
+
+  const postingEndDate = new Date(
+    new Date().setDate(new Date().getDate() + 14),
+  );
+  // End of sample data
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <div>
+      <Text textStyle="display-large">Volunteer Postings</Text>
+      <VolunteerAvailabilityTable
+        postingShifts={postingShifts}
+        postingStartDate={postingStartDate}
+        postingEndDate={postingEndDate}
+      />
+    </div>
+  );
+  //   return !loading && !shifts ? (
+  //     <Redirect to="/not-found" />
+  //   ) : (
+  //     <div>
+  //       <Text textStyle="display-large">Volunteer Postings</Text>
+  //       <VolunteerAvailabilityTable postingShifts={postingShifts} />
+  //     </div>
+  //   );
+};
+
+export default VolunteerPostingAvailabilities;

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useLayoutEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
-import { Box, Text } from "@chakra-ui/react";
+import { Box, HStack, Select, Text } from "@chakra-ui/react";
 
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import { dateInRange } from "../../../../utils/DateTimeUtils";
 import { FilterType } from "../../../../types/DateFilterTypes";
-import NoShiftsAvailableTableRow from "../../../volunteer/shifts/NoShiftsAvailableTableRow";
-import VolunteerAvailabilityTableRow from "../../../volunteer/shifts/VolunteerAvailabilityTableRow";
-import VolunteerAvailabilityTable from "../../../volunteer/shifts/VolunteerAvailabilityTable";
+import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
+import PostingCard from "../../../volunteer/PostingCard";
+import VolunteerNavbar from "../../../volunteer/VolunteerNavbar";
 
 type Posting = Omit<
   PostingResponseDTO,
@@ -93,7 +93,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
 
   return (
     <div>
-      {/* <VolunteerNavbar defaultIndex={1} />
+      <VolunteerNavbar defaultIndex={1} />
       <Box
         bg="background.light"
         pt="48px"
@@ -162,10 +162,6 @@ const VolunteerPostingsPage = (): React.ReactElement => {
             <EmptyPostingCard type="opportunity" />
           )}
         </Box>
-      </Box> */}
-      {/* Temp */}
-      <Box p={25}>
-        <VolunteerAvailabilityTable postingId={1} />
       </Box>
     </div>
   );

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
@@ -13,7 +13,7 @@ import {
 import React from "react";
 import moment from "moment";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
-import { ShiftResponseDTO } from "../../../types/api/ShiftTypes";
+import { ShiftDTO, ShiftResponseDTO } from "../../../types/api/ShiftTypes";
 import NoShiftsAvailableTableRow from "./NoShiftsAvailableTableRow";
 import VolunteerAvailabilityTableRow from "./VolunteerAvailabilityTableRow";
 import { getWeekDiff } from "../../../utils/DateTimeUtils";
@@ -22,12 +22,16 @@ type VolunteerAvailabilityTableProps = {
   postingShifts: ShiftResponseDTO[];
   postingStartDate: Date;
   postingEndDate: Date;
+  selectedShifts: ShiftDTO[];
+  setSelectedShifts: React.Dispatch<React.SetStateAction<ShiftDTO[]>>;
 };
 
 const VolunteerAvailabilityTable = ({
   postingShifts,
   postingStartDate,
   postingEndDate,
+  selectedShifts,
+  setSelectedShifts,
 }: VolunteerAvailabilityTableProps): React.ReactElement => {
   // Side note: I think we should try to avoid doing queries in table components when avbailable03
   // Query to get some posting
@@ -37,7 +41,6 @@ const VolunteerAvailabilityTable = ({
   const [currentWeek, setWeek] = React.useState(
     moment(postingStartDate).startOf("week").toDate(),
   );
-  const [shifts, setShifts] = React.useState(postingShifts);
   return (
     <Box
       bgColor="white"
@@ -74,7 +77,6 @@ const VolunteerAvailabilityTable = ({
             .fill(0)
             .map((_, i) => i)
             .map((week) => {
-              console.log(`week: ${week}`);
               const startWeek = moment(postingStartDate)
                 .startOf("week")
                 .add(week, "weeks")
@@ -115,9 +117,13 @@ const VolunteerAvailabilityTable = ({
           const date = moment(currentWeek)
             .startOf("week")
             .add(day, "days")
+            .startOf("day")
             .toDate();
-          const weeklyShifts = shifts.filter(
-            (shift) => moment(shift.startTime).diff(date, "days", false) === 0,
+          const shiftsOfDate = postingShifts.filter(
+            (shift) =>
+              moment(shift.startTime)
+                .startOf("day")
+                .diff(date, "days", false) === 0,
           );
 
           return (
@@ -134,18 +140,21 @@ const VolunteerAvailabilityTable = ({
                   </Text>
                 </Td>
               </Tr>
-              {weeklyShifts.length < 1 ? (
+              {shiftsOfDate.length < 1 ? (
                 <Tr>
                   <Td>
                     <NoShiftsAvailableTableRow />
                   </Td>
                 </Tr>
               ) : (
-                weeklyShifts.map((shift, index) => {
+                shiftsOfDate.map((shift, index) => {
                   return (
                     <Tr key={`${day}-${index}`}>
                       <Td p={0}>
                         <VolunteerAvailabilityTableRow
+                          shift={shift}
+                          selectedShifts={selectedShifts}
+                          setSelectedShifts={setSelectedShifts}
                           start={shift.startTime}
                           end={shift.endTime}
                         />

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
@@ -13,17 +13,20 @@ import {
 import React from "react";
 import moment from "moment";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
-import { ShiftDTO, ShiftResponseDTO } from "../../../types/api/ShiftTypes";
+import { ShiftResponseDTO } from "../../../types/api/ShiftTypes";
 import NoShiftsAvailableTableRow from "./NoShiftsAvailableTableRow";
 import VolunteerAvailabilityTableRow from "./VolunteerAvailabilityTableRow";
 import { getWeekDiff } from "../../../utils/DateTimeUtils";
+import { SignupRequestDTO } from "../../../types/api/SignupTypes";
 
 type VolunteerAvailabilityTableProps = {
   postingShifts: ShiftResponseDTO[];
   postingStartDate: Date;
   postingEndDate: Date;
-  selectedShifts: ShiftDTO[];
-  setSelectedShifts: React.Dispatch<React.SetStateAction<ShiftDTO[]>>;
+  selectedShifts: ShiftResponseDTO[];
+  setSelectedShifts: React.Dispatch<React.SetStateAction<ShiftResponseDTO[]>>;
+  signupNotes: SignupRequestDTO[];
+  setSignupNotes: React.Dispatch<React.SetStateAction<SignupRequestDTO[]>>;
 };
 
 const VolunteerAvailabilityTable = ({
@@ -32,12 +35,9 @@ const VolunteerAvailabilityTable = ({
   postingEndDate,
   selectedShifts,
   setSelectedShifts,
+  signupNotes,
+  setSignupNotes,
 }: VolunteerAvailabilityTableProps): React.ReactElement => {
-  // Side note: I think we should try to avoid doing queries in table components when avbailable03
-  // Query to get some posting
-  // We assume that we have some posting
-  // we generate an item in the the headers menu for each week between start and end state
-
   const [currentWeek, setWeek] = React.useState(
     moment(postingStartDate).startOf("week").toDate(),
   );
@@ -155,6 +155,8 @@ const VolunteerAvailabilityTable = ({
                           shift={shift}
                           selectedShifts={selectedShifts}
                           setSelectedShifts={setSelectedShifts}
+                          signupNotes={signupNotes}
+                          setSignupNotes={setSignupNotes}
                           start={shift.startTime}
                           end={shift.endTime}
                         />

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTable.tsx
@@ -13,67 +13,29 @@ import {
 import React from "react";
 import moment from "moment";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
+import { ShiftResponseDTO } from "../../../types/api/ShiftTypes";
 import NoShiftsAvailableTableRow from "./NoShiftsAvailableTableRow";
 import VolunteerAvailabilityTableRow from "./VolunteerAvailabilityTableRow";
 import { getWeekDiff } from "../../../utils/DateTimeUtils";
 
-type VolunteerAvailabilityTableProps = { postingId: number };
-
-// Temp type
-type Shift = {
-  startTime: Date;
-  endTime: Date;
+type VolunteerAvailabilityTableProps = {
+  postingShifts: ShiftResponseDTO[];
+  postingStartDate: Date;
+  postingEndDate: Date;
 };
 
 const VolunteerAvailabilityTable = ({
-  postingId,
+  postingShifts,
+  postingStartDate,
+  postingEndDate,
 }: VolunteerAvailabilityTableProps): React.ReactElement => {
   // Side note: I think we should try to avoid doing queries in table components when avbailable03
   // Query to get some posting
-
   // We assume that we have some posting
   // we generate an item in the the headers menu for each week between start and end state
 
-  // Sample data
-  const postingStartDate = new Date(
-    new Date().setDate(new Date().getDate() - 14),
-  );
-
-  const postingEndDate = new Date(
-    new Date().setDate(new Date().getDate() + 14),
-  );
-
-  // Maybe put under use effect
-  const postingStartWeek = new Date(
-    new Date().setDate(postingStartDate.getDate() - postingStartDate.getDay()),
-  );
-
-  const postingShifts: Shift[] = [
-    {
-      startTime: new Date(),
-      endTime: new Date(Date.now() + 2.25 * 1000 * 60 * 60),
-    },
-    {
-      startTime: new Date(Date.now() + 3 * 1000 * 60 * 60),
-      endTime: new Date(Date.now() + 4 * 1000 * 60 * 60),
-    },
-    {
-      startTime: new Date(
-        new Date(Date.now() + 2 * 1000 * 60 * 60).setDate(
-          new Date().getDate() + 1,
-        ),
-      ),
-      endTime: new Date(
-        new Date(Date.now() + 2.5 * 1000 * 60 * 60).setDate(
-          new Date().getDate() + 1,
-        ),
-      ),
-    },
-  ];
-  // End of sample data
-
   const [currentWeek, setWeek] = React.useState(
-    moment(postingStartWeek).startOf("week").toDate(),
+    moment(postingStartDate).startOf("week").toDate(),
   );
   const [shifts, setShifts] = React.useState(postingShifts);
   return (

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
@@ -11,23 +11,41 @@ import {
   formatTimeHourMinutes,
   getElapsedHours,
 } from "../../../utils/DateTimeUtils";
+import { ShiftDTO } from "../../../types/api/ShiftTypes";
 
-type VolunteerAvailabilityTableRowProps = { start: Date; end: Date };
+type VolunteerAvailabilityTableRowProps = {
+  shift: ShiftDTO;
+  selectedShifts: ShiftDTO[];
+  setSelectedShifts: React.Dispatch<React.SetStateAction<ShiftDTO[]>>;
+  start: Date;
+  end: Date;
+};
 
 const VolunteerAvailabilityTableRow = ({
+  shift,
+  selectedShifts,
+  setSelectedShifts,
   start,
   end,
 }: VolunteerAvailabilityTableRowProps): React.ReactElement => {
   const [note, setNote] = React.useState("");
-  const [checked, setChecked] = React.useState(false);
+  const [checked, setChecked] = React.useState(selectedShifts.includes(shift));
 
   return (
     <Flex bgColor={checked ? "purple.50" : undefined} px={25} py={3}>
       <Checkbox
         minWidth={300}
         mr={170}
-        checked={checked}
-        onChange={(event) => setChecked(event.target.checked)}
+        isChecked={checked}
+        onChange={(event) => {
+          if (!checked) {
+            setSelectedShifts([...selectedShifts, shift]);
+          } else {
+            const selected = selectedShifts.filter((s) => s !== shift);
+            setSelectedShifts(selected);
+          }
+          setChecked(event.target.checked);
+        }}
       >
         {`${formatTimeHourMinutes(start)} -  ${formatTimeHourMinutes(
           end,

--- a/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerAvailabilityTableRow.tsx
@@ -11,12 +11,15 @@ import {
   formatTimeHourMinutes,
   getElapsedHours,
 } from "../../../utils/DateTimeUtils";
-import { ShiftDTO } from "../../../types/api/ShiftTypes";
+import { ShiftResponseDTO } from "../../../types/api/ShiftTypes";
+import { SignupRequestDTO } from "../../../types/api/SignupTypes";
 
 type VolunteerAvailabilityTableRowProps = {
-  shift: ShiftDTO;
-  selectedShifts: ShiftDTO[];
-  setSelectedShifts: React.Dispatch<React.SetStateAction<ShiftDTO[]>>;
+  shift: ShiftResponseDTO;
+  selectedShifts: ShiftResponseDTO[];
+  setSelectedShifts: React.Dispatch<React.SetStateAction<ShiftResponseDTO[]>>;
+  signupNotes: SignupRequestDTO[];
+  setSignupNotes: React.Dispatch<React.SetStateAction<SignupRequestDTO[]>>;
   start: Date;
   end: Date;
 };
@@ -25,11 +28,19 @@ const VolunteerAvailabilityTableRow = ({
   shift,
   selectedShifts,
   setSelectedShifts,
+  signupNotes,
+  setSignupNotes,
   start,
   end,
 }: VolunteerAvailabilityTableRowProps): React.ReactElement => {
-  const [note, setNote] = React.useState("");
   const [checked, setChecked] = React.useState(selectedShifts.includes(shift));
+  const signupNote = React.useMemo(() => {
+    const note = signupNotes.find((s) => s.shiftId === shift.id);
+    if (note) {
+      return note.note;
+    }
+    return "";
+  }, [signupNotes, shift]);
 
   return (
     <Flex bgColor={checked ? "purple.50" : undefined} px={25} py={3}>
@@ -56,11 +67,21 @@ const VolunteerAvailabilityTableRow = ({
           isDisabled={!checked}
           bg="white"
           placeholder="Add note (optional)"
-          value={note}
-          onChange={(event) => setNote(event.target.value)}
+          onChange={(event) => {
+            const otherNotes = signupNotes.filter(
+              (s) => s.shiftId !== shift.id,
+            );
+            setSignupNotes([
+              ...otherNotes,
+              {
+                shiftId: shift.id,
+                note: event.target.value.toString().trim(),
+              },
+            ]);
+          }}
         />
         <InputRightElement
-          visibility={note.trim().length > 0 && checked ? "visible" : "hidden"}
+          visibility={signupNote.length > 0 && checked ? "visible" : "hidden"}
         >
           <CheckIcon color="brand.500" />
         </InputRightElement>

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -36,3 +36,6 @@ export const ADMIN_POSTING_CREATE_REVIEW_PAGE = "/admin/posting/create/review";
 export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
 
 export const ADMIN_POSTING_DETAILS = "/admin/posting/:id";
+
+export const VOLUNTEER_POSTING_AVAILABILITIES =
+  "/volunteer/posting/:id/availabilities";

--- a/frontend/src/types/api/SignupTypes.ts
+++ b/frontend/src/types/api/SignupTypes.ts
@@ -1,0 +1,14 @@
+export type SignupDTO = {
+  id: string;
+  shiftId: string;
+  userId: string;
+  numVolunteers: number;
+  note: string;
+};
+
+export type SignupRequestDTO = Omit<
+  SignupDTO,
+  "id" | "numVolunteers" | "userId"
+>;
+
+export type SignupResponseDTO = SignupDTO;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #129 

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description

https://user-images.githubusercontent.com/44826218/158919383-94b72bb3-b2ac-4821-80a5-f92417faa9f7.mp4

- Added base page for select shift
- Added top level shift saving with notes
- Added new note type for client side prop drilling
- Added get shift by posting id query
- Created page called `/volunteer/posting/:id/availabilities` which does a datafetch on shifts and posting details for table

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run seed and go to  `/volunteer/posting/:id/availabilities` for id 1 and 2
2. Table page should work properly - checkboxes should persist through pagination
3. On press on submit, console log all selected shifts from top level page (used later for submission query)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness + edge cases not in ticket
* Any redundancy
* Frontend layout

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
