### PR TITLE
Implement skill and employee tag popovers

### DIFF
--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -26,6 +26,7 @@ import {
 import { QuestionOutlineIcon } from "@chakra-ui/icons";
 
 import FormHeader from "../../common/FormHeader";
+import TagsPopover from "../../common/TagsPopover";
 import {
   ADMIN_POSTING_CREATE_BASIC_INFO_CLOSING_DATE_TOOLTIP,
   ADMIN_POSTING_CREATE_BASIC_INFO_ENTER_ALL_DETAILS,
@@ -436,16 +437,33 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                   wrap="wrap"
                   mb={skillsError ? ERROR_MESSAGE_HEIGHT : "0px"}
                 >
-                  {selectedSkills.map((skillId) => (
+                  {selectedSkills.slice(0, 2).map((skillId) => (
                     <Tag variant="brand" height="32px" key={skillId}>
-                      <TagLabel>
-                        {getOptionNameFromId(skillOptions, skillId)}
-                      </TagLabel>
+                      {getOptionNameFromId(skillOptions, skillId)}
                       <TagCloseButton
                         onClick={() => handleSkillRemoval(skillId)}
                       />
                     </Tag>
                   ))}
+                  {selectedSkills.length > 2 && (
+                    <TagsPopover
+                      header="Selected Skills"
+                      tags={selectedSkills.map((skillId) => (
+                        <Tag
+                          variant="brand"
+                          height="32px"
+                          key={skillId}
+                          mr={2}
+                          mb={2}
+                        >
+                          {getOptionNameFromId(skillOptions, skillId)}
+                          <TagCloseButton
+                            onClick={() => handleSkillRemoval(skillId)}
+                          />
+                        </Tag>
+                      ))}
+                    />
+                  )}
                 </HStack>
               </FormControl>
             </HStack>
@@ -477,25 +495,49 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                   wrap="wrap"
                   mb={employeesError ? ERROR_MESSAGE_HEIGHT : "0px"}
                 >
-                  {selectedEmployees.map((employeeId) => (
+                  {selectedEmployees.slice(0, 2).map((employeeId) => (
                     <Tag variant="brand" height="32px" key={employeeId}>
                       <Avatar size="xs" mr={1} bg="violet" />
-                      <TagLabel>
-                        {getOptionNameFromId(
-                          employeeOptions.map(
-                            ({ id, firstName, lastName }) => ({
-                              id,
-                              name: `${firstName} ${lastName}`,
-                            }),
-                          ),
-                          employeeId,
-                        )}
-                      </TagLabel>
+                      {getOptionNameFromId(
+                        employeeOptions.map(({ id, firstName, lastName }) => ({
+                          id,
+                          name: `${firstName} ${lastName}`,
+                        })),
+                        employeeId,
+                      )}
                       <TagCloseButton
                         onClick={() => handleEmployeeRemoval(employeeId)}
                       />
                     </Tag>
                   ))}
+                  {selectedEmployees.length > 2 && (
+                    <TagsPopover
+                      header="Appointed Contacts"
+                      tags={selectedEmployees.map((employeeId) => (
+                        <Tag
+                          variant="brand"
+                          height="32px"
+                          key={employeeId}
+                          mr={2}
+                          mb={2}
+                        >
+                          <Avatar size="xs" mr={1} bg="violet" />
+                          {getOptionNameFromId(
+                            employeeOptions.map(
+                              ({ id, firstName, lastName }) => ({
+                                id,
+                                name: `${firstName} ${lastName}`,
+                              }),
+                            ),
+                            employeeId,
+                          )}
+                          <TagCloseButton
+                            onClick={() => handleEmployeeRemoval(employeeId)}
+                          />
+                        </Tag>
+                      ))}
+                    />
+                  )}
                 </HStack>
               </FormControl>
             </HStack>

--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -18,11 +18,17 @@ import {
   Select,
   Tag,
   TagCloseButton,
-  TagLabel,
   Text,
   Textarea,
   Tooltip,
   VStack,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverBody,
+  PopoverArrow,
+  PopoverCloseButton,
 } from "@chakra-ui/react";
 import { QuestionOutlineIcon } from "@chakra-ui/icons";
 

--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -446,9 +446,9 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                       mb={2}
                     >
                       {getOptionNameFromId(skillOptions, skillId)}
-                      {/* <TagCloseButton
+                      <TagCloseButton
                         onClick={() => handleSkillRemoval(skillId)}
-                      /> */}
+                      />
                     </Tag>
                   ))}
                   {selectedSkills.length > 2 && (

--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -22,13 +22,6 @@ import {
   Textarea,
   Tooltip,
   VStack,
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-  PopoverHeader,
-  PopoverBody,
-  PopoverArrow,
-  PopoverCloseButton,
 } from "@chakra-ui/react";
 import { QuestionOutlineIcon } from "@chakra-ui/icons";
 

--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -431,18 +431,24 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
               </FormControl>
               <FormControl>
                 <FormLabel textStyle="body-regular">Selected Skills</FormLabel>
-                <HStack
-                  spacing={4}
+                <Flex
+                  spacing={0}
                   minHeight="32px"
                   wrap="wrap"
                   mb={skillsError ? ERROR_MESSAGE_HEIGHT : "0px"}
                 >
                   {selectedSkills.slice(0, 2).map((skillId) => (
-                    <Tag variant="brand" height="32px" key={skillId}>
+                    <Tag
+                      variant="brand"
+                      height="32px"
+                      key={skillId}
+                      mr={4}
+                      mb={2}
+                    >
                       {getOptionNameFromId(skillOptions, skillId)}
-                      <TagCloseButton
+                      {/* <TagCloseButton
                         onClick={() => handleSkillRemoval(skillId)}
-                      />
+                      /> */}
                     </Tag>
                   ))}
                   {selectedSkills.length > 2 && (
@@ -464,7 +470,7 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                       ))}
                     />
                   )}
-                </HStack>
+                </Flex>
               </FormControl>
             </HStack>
             <HStack spacing={7} w="full">
@@ -489,14 +495,20 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                 <FormLabel textStyle="body-regular">
                   Appointed Contacts
                 </FormLabel>
-                <HStack
-                  spacing={4}
+                <Flex
+                  spacing={0}
                   minHeight="32px"
                   wrap="wrap"
                   mb={employeesError ? ERROR_MESSAGE_HEIGHT : "0px"}
                 >
                   {selectedEmployees.slice(0, 2).map((employeeId) => (
-                    <Tag variant="brand" height="32px" key={employeeId}>
+                    <Tag
+                      variant="brand"
+                      height="32px"
+                      key={employeeId}
+                      mr={4}
+                      mb={2}
+                    >
                       <Avatar size="xs" mr={1} bg="violet" />
                       {getOptionNameFromId(
                         employeeOptions.map(({ id, firstName, lastName }) => ({
@@ -538,7 +550,7 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                       ))}
                     />
                   )}
-                </HStack>
+                </Flex>
               </FormControl>
             </HStack>
           </VStack>

--- a/frontend/src/components/common/TagsPopover.tsx
+++ b/frontend/src/components/common/TagsPopover.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  Tag,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverBody,
+  PopoverArrow,
+  PopoverCloseButton,
+} from "@chakra-ui/react";
+
+type TagsPopoverProps = {
+  header: string;
+  tags: React.ReactElement[];
+};
+
+const TagsPopover: React.FC<TagsPopoverProps> = ({
+  header,
+  tags,
+}: TagsPopoverProps) => {
+  return (
+    <Popover placement="top">
+      <PopoverTrigger>
+        <Tag variant="brand" height="32px">
+          +{tags.length - 2}
+        </Tag>
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader>{header}</PopoverHeader>
+        <PopoverBody>{tags}</PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default TagsPopover;

--- a/frontend/src/components/common/TagsPopover.tsx
+++ b/frontend/src/components/common/TagsPopover.tsx
@@ -22,7 +22,7 @@ const TagsPopover: React.FC<TagsPopoverProps> = ({
   return (
     <Popover placement="top">
       <PopoverTrigger>
-        <Tag variant="brand" height="32px">
+        <Tag variant="brand" height="32px" mr={4}>
           +{tags.length - 2}
         </Tag>
       </PopoverTrigger>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #192 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Used Chakra UI popover components to create popover for skill and employee tags in create posting basic info form
* There was a small issue where the text in the skill and employee tags were not being center aligned - fixed this by removing the `TagLabel` component that wrapped around the text


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to the create posting info form
2. Add some skills and employees. Note: you may have to create more skills and employees in the database to test the popover functionality
3. Once you have more than 2 skills or employees selected, you can click the +`x` tag (where `x = [number of selected tags] - 2` to see the popover


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness
* Is it okay to remove the `TagLabel` component? I didn't use it for the tags in the review postings page, not sure if it's required.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
