### PR TITLE
Add Published to Signupstatus Enum

### DIFF
--- a/backend/graphql/types/shiftSignupType.ts
+++ b/backend/graphql/types/shiftSignupType.ts
@@ -5,6 +5,7 @@ const shiftSignupType = gql`
     PENDING
     CONFIRMED
     CANCELED
+    PUBLISHED
   }
 
   input CreateShiftSignupRequestDTO {

--- a/backend/prisma/migrations/20220320210021_add_published_signup_status/migration.sql
+++ b/backend/prisma/migrations/20220320210021_add_published_signup_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SignupStatus" ADD VALUE 'PUBLISHED';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -45,6 +45,7 @@ enum SignupStatus {
   PENDING
   CONFIRMED
   CANCELED
+  PUBLISHED
 }
 
 enum PostingType {

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -115,7 +115,11 @@ export type ShiftBulkRequestDTO = {
 
 export type ShiftResponseDTO = ShiftDTO;
 
-export type ShiftSignupStatus = "PENDING" | "CONFIRMED" | "CANCELED" | "PUBLISHED";
+export type ShiftSignupStatus =
+  | "PENDING"
+  | "CONFIRMED"
+  | "CANCELED"
+  | "PUBLISHED";
 
 export type ShiftSignupDTO = {
   shiftId: string;

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -115,7 +115,7 @@ export type ShiftBulkRequestDTO = {
 
 export type ShiftResponseDTO = ShiftDTO;
 
-export type ShiftSignupStatus = "PENDING" | "CONFIRMED" | "CANCELED";
+export type ShiftSignupStatus = "PENDING" | "CONFIRMED" | "CANCELED" | "PUBLISHED";
 
 export type ShiftSignupDTO = {
   shiftId: string;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #209 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added a published status to the signupStatus enum to shiftSignupType.ts, schema.prisma, and types.ts



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* adding published to enum is implemented properly 


## Checklist
- [x ] My PR name is descriptive and in imperative tense
- [x ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ x] I have run the appropriate linter(s)
- [ x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
