### PR TITLE
Add signup shifts query by posting id

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -162,7 +162,7 @@ const graphQLMiddlewares = {
     branch: authorizedByAdmin(),
     branches: authorizedByAdmin(),
     getShiftSignupsForUser: authorizedByAdmin(),
-    getShiftSignupsForPostingInDateRange: authorizedByAdmin(),
+    getShiftSignupsForPosting: authorizedByAdmin(),
   },
   Mutation: {
     createEntity: authorizedByAllRoles(),

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -162,6 +162,7 @@ const graphQLMiddlewares = {
     branch: authorizedByAdmin(),
     branches: authorizedByAdmin(),
     getShiftSignupsForUser: authorizedByAdmin(),
+    getShiftSignupsForPostingInDateRange: authorizedByAdmin(),
   },
   Mutation: {
     createEntity: authorizedByAllRoles(),

--- a/backend/graphql/resolvers/shiftSignupResolvers.ts
+++ b/backend/graphql/resolvers/shiftSignupResolvers.ts
@@ -20,6 +20,28 @@ const shiftSignupResolvers = {
     ): Promise<ShiftSignupResponseDTO[]> => {
       return shiftSignupService.getShiftSignupsForUser(userId, signupStatus);
     },
+
+    getShiftSignupsForPostingInDateRange: async (
+      _parent: undefined,
+      {
+        postingId,
+        startDate,
+        endDate,
+        signupStatus,
+      }: {
+        postingId: string;
+        startDate: Date;
+        endDate: Date;
+        signupStatus: SignupStatus | null;
+      },
+    ): Promise<ShiftSignupResponseDTO[]> => {
+      return shiftSignupService.getShiftSignupsForPostingInDateRange(
+        postingId,
+        startDate,
+        endDate,
+        signupStatus,
+      );
+    },
   },
   Mutation: {
     createShiftSignups: async (

--- a/backend/graphql/resolvers/shiftSignupResolvers.ts
+++ b/backend/graphql/resolvers/shiftSignupResolvers.ts
@@ -21,24 +21,18 @@ const shiftSignupResolvers = {
       return shiftSignupService.getShiftSignupsForUser(userId, signupStatus);
     },
 
-    getShiftSignupsForPostingInDateRange: async (
+    getShiftSignupsForPosting: async (
       _parent: undefined,
       {
         postingId,
-        startDate,
-        endDate,
         signupStatus,
       }: {
         postingId: string;
-        startDate: Date;
-        endDate: Date;
         signupStatus: SignupStatus | null;
       },
     ): Promise<ShiftSignupResponseDTO[]> => {
-      return shiftSignupService.getShiftSignupsForPostingInDateRange(
+      return shiftSignupService.getShiftSignupsForPosting(
         postingId,
-        startDate,
-        endDate,
         signupStatus,
       );
     },

--- a/backend/graphql/types/shiftSignupType.ts
+++ b/backend/graphql/types/shiftSignupType.ts
@@ -35,10 +35,8 @@ const shiftSignupType = gql`
       userId: ID!
       signupStatus: SignupStatus
     ): [ShiftSignupResponseDTO!]!
-    getShiftSignupsForPostingInDateRange(
+    getShiftSignupsForPosting(
       postingId: ID!
-      startDate: DateTime!
-      endDate: DateTime!
       signupStatus: SignupStatus
     ): [ShiftSignupResponseDTO!]!
   }

--- a/backend/graphql/types/shiftSignupType.ts
+++ b/backend/graphql/types/shiftSignupType.ts
@@ -35,6 +35,12 @@ const shiftSignupType = gql`
       userId: ID!
       signupStatus: SignupStatus
     ): [ShiftSignupResponseDTO!]!
+    getShiftSignupsForPostingInDateRange(
+      postingId: ID!
+      startDate: DateTime!
+      endDate: DateTime!
+      signupStatus: SignupStatus
+    ): [ShiftSignupResponseDTO!]!
   }
 
   extend type Mutation {

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -62,10 +62,8 @@ class ShiftSignupService implements IShiftSignupService {
     }
   }
 
-  async getShiftSignupsForPostingInDateRange(
+  async getShiftSignupsForPosting(
     postingId: string,
-    startDate: Date,
-    endDate: Date,
     signupStatus: SignupStatus | null,
   ): Promise<ShiftSignupResponseDTO[]> {
     try {
@@ -74,10 +72,6 @@ class ShiftSignupService implements IShiftSignupService {
           {
             shift: {
               postingId: Number(postingId),
-              startTime: {
-                gte: startDate,
-                lte: endDate,
-              },
             },
           },
           signupStatus

--- a/backend/services/interfaces/shiftSignupService.ts
+++ b/backend/services/interfaces/shiftSignupService.ts
@@ -40,6 +40,21 @@ interface IShiftSignupService {
     userId: string,
     signupStatus: SignupStatus | null,
   ): Promise<ShiftSignupResponseDTO[]>;
+
+  /**
+   * Gets all shifts for a posting within a date range
+   * @param postingId the target posting's id
+   * @param startDate the start range to filter
+   * @param endDate the end range to filter
+   * @returns an array of ShiftSignupResponseDTOs for each shift within the date range
+   * @throws Error if the shift signup retrieval fails
+   */
+  getShiftSignupsForPostingInDateRange(
+    postingId: string,
+    startDate: Date,
+    endDate: Date,
+    signupStatus: SignupStatus | null,
+  ): Promise<ShiftSignupResponseDTO[]>;
 }
 
 export default IShiftSignupService;

--- a/backend/services/interfaces/shiftSignupService.ts
+++ b/backend/services/interfaces/shiftSignupService.ts
@@ -42,17 +42,13 @@ interface IShiftSignupService {
   ): Promise<ShiftSignupResponseDTO[]>;
 
   /**
-   * Gets all shifts for a posting within a date range
+   * Gets all shifts for a posting
    * @param postingId the target posting's id
-   * @param startDate the start range to filter
-   * @param endDate the end range to filter
-   * @returns an array of ShiftSignupResponseDTOs for each shift within the date range
+   * @returns an array of ShiftSignupResponseDTOs for each shift for posting
    * @throws Error if the shift signup retrieval fails
    */
-  getShiftSignupsForPostingInDateRange(
+  getShiftSignupsForPosting(
     postingId: string,
-    startDate: Date,
-    endDate: Date,
     signupStatus: SignupStatus | null,
   ): Promise<ShiftSignupResponseDTO[]>;
 }


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #190 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add simple query to get signup shifts by posting ids


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. create signup shifts of posting
2. call query to get created queries


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* correctness


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
