### PR TITLE
Use RichTextDisplay in posting details page

### DIFF
--- a/frontend/src/components/common/PostingDetails.tsx
+++ b/frontend/src/components/common/PostingDetails.tsx
@@ -13,6 +13,7 @@ import PocCard from "./PocCard";
 
 import { PostingResponseDTO } from "../../types/api/PostingTypes";
 import { formatDateStringYear } from "../../utils/DateTimeUtils";
+import RichTextDisplay from "./RichText/RichTextDisplay";
 
 type PostingDetailsProps = {
   postingDetails: PostingResponseDTO;
@@ -56,7 +57,7 @@ const PostingDetails = ({
           ))}
         </HStack>
         <Text textStyle="body-regular" py={4}>
-          {postingDetails.description}
+          <RichTextDisplay>{postingDetails.description}</RichTextDisplay>
         </Text>
         <Text textStyle="body-regular">Point(s) of contact:</Text>
         <HStack pb={4}>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #131 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Wrapped the postingDetails description inside the RichTextDisplay component created in #130 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Follow testing instructions in https://github.com/uwblueprint/sistering/pull/140 , but replace the description field of the createPosting mutation with the following richText samples:
- "{\"blocks\":[{\"key\":\"2ggjh\",\"text\":\"hi\",\"type\":\"ordered-list-item\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"2nlb2\",\"text\":\"aewf\",\"type\":\"ordered-list-item\",\"depth\":0,\"inlineStyleRanges\":[{\"offset\":0,\"length\":4,\"style\":\"BOLD\"}],\"entityRanges\":[],\"data\":{}},{\"key\":\"6a81d\",\"text\":\"asf\",\"type\":\"ordered-list-item\",\"depth\":0,\"inlineStyleRanges\":[{\"offset\":0,\"length\":3,\"style\":\"BOLD\"},{\"offset\":0,\"length\":3,\"style\":\"UNDERLINE\"}],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}"
- "{\"blocks\":[{\"key\":\"2ggjh\",\"text\":\"ajwefiojeio\",\"type\":\"unordered-list-item\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"80c8b\",\"text\":\"jasidf\",\"type\":\"unordered-list-item\",\"depth\":0,\"inlineStyleRanges\":[{\"offset\":0,\"length\":6,\"style\":\"BOLD\"},{\"offset\":0,\"length\":6,\"style\":\"UNDERLINE\"},{\"offset\":0,\"length\":6,\"style\":\"ITALIC\"}],\"entityRanges\":[],\"data\":{}},{\"key\":\"4qepd\",\"text\":\"ajewoifjwejo\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[{\"offset\":0,\"length\":12,\"style\":\"BOLD\"},{\"offset\":0,\"length\":12,\"style\":\"UNDERLINE\"},{\"offset\":0,\"length\":12,\"style\":\"ITALIC\"}],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}"

Which should display the following
![image](https://user-images.githubusercontent.com/82241706/160298708-1aef253f-5cb9-46d8-a1b4-f24bbbd5533a.png)
![image](https://user-images.githubusercontent.com/82241706/160298709-a1609017-4b3d-46af-abaf-032381a96494.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Verify the description is displayed properly in richtext


## Checklist
- [x ] My PR name is descriptive and in imperative tense
- [ x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x ] I have run the appropriate linter(s)
- [x ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
