### PR TITLE
Add posting fields to shiftSignup fetch

### DIFF
--- a/backend/graphql/types/shiftSignupType.ts
+++ b/backend/graphql/types/shiftSignupType.ts
@@ -29,6 +29,9 @@ const shiftSignupType = gql`
     numVolunteers: Int!
     note: String!
     status: SignupStatus!
+    postingId: ID!
+    postingTitle: String!
+    autoClosingDate: Date!
   }
 
   extend type Query {

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -139,6 +139,9 @@ export type UpdateShiftSignupRequestDTO = Omit<
 export type ShiftSignupResponseDTO = {
   shiftStartTime: Date;
   shiftEndTime: Date;
+  postingId: string;
+  postingTitle: string;
+  autoClosingDate: Date;
 } & ShiftSignupDTO;
 
 export type SkillDTO = {


### PR DESCRIPTION
## Ticket link
Doesn't close a ticket, but required for #127 

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated the get endpoint for shiftSignup to include posting fields 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the docker container 
2. Go to GraphQL playground and verify that the posting details (id, title, and autoClosingDate) are returned as expected


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code cleanliness and functionality 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
