### PR TITLE
Add submit signups mutation to availability page

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -198,6 +198,7 @@ const graphQLMiddlewares = {
     deleteBranch: authorizedByAdmin(),
     createShiftSignups: isAuthorizedForCreateShiftSignups("userId"),
     updateShiftSignup: isAuthorizedForUpdateShiftSignups("userId"),
+    upsertDeleteShiftSignups: isAuthorizedForUpdateShiftSignups("userId"),
   },
 };
 

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -198,7 +198,7 @@ const graphQLMiddlewares = {
     deleteBranch: authorizedByAdmin(),
     createShiftSignups: isAuthorizedForCreateShiftSignups("userId"),
     updateShiftSignup: isAuthorizedForUpdateShiftSignups("userId"),
-    upsertDeleteShiftSignups: isAuthorizedForUpdateShiftSignups("userId"),
+    upsertDeleteShiftSignups: authorizedByAdminAndVolunteer(),
   },
 };
 

--- a/backend/graphql/resolvers/shiftSignupResolvers.ts
+++ b/backend/graphql/resolvers/shiftSignupResolvers.ts
@@ -3,11 +3,9 @@ import ShiftSignupService from "../../services/implementations/shiftSignupServic
 import IShiftSignupService from "../../services/interfaces/shiftSignupService";
 import {
   CreateShiftSignupDTO,
-  DeleteShiftSignupDTO,
   ShiftSignupResponseDTO,
   UpdateShiftSignupRequestDTO,
   UpsertDeleteShiftSignupsRequestDTO,
-  UpsertShiftSignupDTO,
 } from "../../types";
 
 const shiftSignupService: IShiftSignupService = new ShiftSignupService();

--- a/backend/graphql/resolvers/shiftSignupResolvers.ts
+++ b/backend/graphql/resolvers/shiftSignupResolvers.ts
@@ -3,8 +3,11 @@ import ShiftSignupService from "../../services/implementations/shiftSignupServic
 import IShiftSignupService from "../../services/interfaces/shiftSignupService";
 import {
   CreateShiftSignupDTO,
+  DeleteShiftSignupDTO,
   ShiftSignupResponseDTO,
   UpdateShiftSignupRequestDTO,
+  UpsertDeleteShiftSignupsRequestDTO,
+  UpsertShiftSignupDTO,
 } from "../../types";
 
 const shiftSignupService: IShiftSignupService = new ShiftSignupService();
@@ -58,6 +61,22 @@ const shiftSignupResolvers = {
       },
     ): Promise<ShiftSignupResponseDTO> => {
       return shiftSignupService.updateShiftSignup(shiftId, userId, update);
+    },
+
+    upsertDeleteShiftSignups: async (
+      _parent: undefined,
+      {
+        upsertShifts,
+        deleteShifts,
+      }: {
+        upsertShifts: UpsertShiftSignupDTO[];
+        deleteShifts: DeleteShiftSignupDTO[];
+      },
+    ): Promise<ShiftSignupResponseDTO[]> => {
+      return shiftSignupService.upsertDeleteShiftSignups({
+        upsertShiftSignups: upsertShifts,
+        deleteShiftSignups: deleteShifts,
+      } as UpsertDeleteShiftSignupsRequestDTO);
     },
   },
 };

--- a/backend/graphql/resolvers/shiftSignupResolvers.ts
+++ b/backend/graphql/resolvers/shiftSignupResolvers.ts
@@ -66,17 +66,12 @@ const shiftSignupResolvers = {
     upsertDeleteShiftSignups: async (
       _parent: undefined,
       {
-        upsertShifts,
-        deleteShifts,
+        upsertDeleteShifts,
       }: {
-        upsertShifts: UpsertShiftSignupDTO[];
-        deleteShifts: DeleteShiftSignupDTO[];
+        upsertDeleteShifts: UpsertDeleteShiftSignupsRequestDTO;
       },
     ): Promise<ShiftSignupResponseDTO[]> => {
-      return shiftSignupService.upsertDeleteShiftSignups({
-        upsertShiftSignups: upsertShifts,
-        deleteShiftSignups: deleteShifts,
-      } as UpsertDeleteShiftSignupsRequestDTO);
+      return shiftSignupService.upsertDeleteShiftSignups(upsertDeleteShifts);
     },
   },
 };

--- a/backend/graphql/resolvers/shiftSignupResolvers.ts
+++ b/backend/graphql/resolvers/shiftSignupResolvers.ts
@@ -69,7 +69,10 @@ const shiftSignupResolvers = {
         upsertDeleteShifts: UpsertDeleteShiftSignupsRequestDTO;
       },
     ): Promise<ShiftSignupResponseDTO[]> => {
-      return shiftSignupService.upsertDeleteShiftSignups(upsertDeleteShifts);
+      return shiftSignupService.upsertDeleteShiftSignups(
+        upsertDeleteShifts.upsertShiftSignups,
+        upsertDeleteShifts.deleteShiftSignups,
+      );
     },
   },
 };

--- a/backend/graphql/types/shiftSignupType.ts
+++ b/backend/graphql/types/shiftSignupType.ts
@@ -21,6 +21,24 @@ const shiftSignupType = gql`
     status: SignupStatus!
   }
 
+  input UpsertShiftSignupRequestDTO {
+    shiftId: ID!
+    userId: ID!
+    numVolunteers: Int!
+    note: String!
+    status: SignupStatus
+  }
+
+  input DeleteShiftSignupRequestDTO {
+    shiftId: ID!
+    userId: ID!
+  }
+
+  input UpsertDeleteShiftSignupRequestDTO {
+    upsertShiftSignups: [UpsertShiftSignupRequestDTO!]!
+    deleteShiftSignups: [DeleteShiftSignupRequestDTO!]!
+  }
+
   type ShiftSignupResponseDTO {
     shiftId: ID!
     shiftStartTime: DateTime!
@@ -51,6 +69,9 @@ const shiftSignupType = gql`
       userId: ID!
       update: UpdateShiftSignupRequestDTO!
     ): ShiftSignupResponseDTO!
+    upsertDeleteShiftSignups(
+      upsertDeleteShifts: UpsertDeleteShiftSignupRequestDTO!
+    ): [ShiftSignupResponseDTO!]!
   }
 `;
 

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -165,8 +165,10 @@ class ShiftSignupService implements IShiftSignupService {
           where: {
             OR: upsertDeleteShiftSignups.deleteShiftSignups.map(
               (deleteShiftSignup) => ({
-                shiftId: Number(deleteShiftSignup.shiftId),
-                userId: Number(deleteShiftSignup.userId),
+                AND: {
+                  shiftId: Number(deleteShiftSignup.shiftId),
+                  userId: Number(deleteShiftSignup.userId),
+                },
               }),
             ),
           },

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -4,9 +4,11 @@ import { Prisma, Shift } from ".prisma/client";
 import IShiftSignupService from "../interfaces/shiftSignupService";
 import {
   CreateShiftSignupDTO,
+  DeleteShiftSignupDTO,
   ShiftSignupResponseDTO,
   UpdateShiftSignupRequestDTO,
   UpsertDeleteShiftSignupsRequestDTO,
+  UpsertShiftSignupDTO,
 } from "../../types";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
@@ -157,50 +159,47 @@ class ShiftSignupService implements IShiftSignupService {
   }
 
   async upsertDeleteShiftSignups(
-    upsertDeleteShiftSignups: UpsertDeleteShiftSignupsRequestDTO,
+    upsertShiftSignups: UpsertShiftSignupDTO[],
+    deleteShiftSignups: DeleteShiftSignupDTO[],
   ): Promise<ShiftSignupResponseDTO[]> {
     try {
       const newShiftSignups = await prisma.$transaction([
         prisma.signup.deleteMany({
           where: {
-            OR: upsertDeleteShiftSignups.deleteShiftSignups.map(
-              (deleteShiftSignup) => ({
-                AND: {
-                  shiftId: Number(deleteShiftSignup.shiftId),
-                  userId: Number(deleteShiftSignup.userId),
-                },
-              }),
-            ),
+            OR: deleteShiftSignups.map((deleteShiftSignup) => ({
+              AND: {
+                shiftId: Number(deleteShiftSignup.shiftId),
+                userId: Number(deleteShiftSignup.userId),
+              },
+            })),
           },
         }),
-        ...upsertDeleteShiftSignups.upsertShiftSignups.map(
-          (upsertShiftSignup) => {
-            const { shiftId, userId, status, ...signup } = upsertShiftSignup;
-            return prisma.signup.upsert({
-              where: {
-                shiftId_userId: {
-                  shiftId: Number(upsertShiftSignup.shiftId),
-                  userId: Number(upsertShiftSignup.userId),
-                },
+        ...upsertShiftSignups.map((upsertShiftSignup) => {
+          const { shiftId, userId, status, ...signup } = upsertShiftSignup;
+          return prisma.signup.upsert({
+            where: {
+              shiftId_userId: {
+                shiftId: Number(upsertShiftSignup.shiftId),
+                userId: Number(upsertShiftSignup.userId),
               },
-              create: {
-                ...signup,
-                status: SignupStatus.PENDING,
-                shiftId: Number(shiftId),
-                userId: Number(userId),
-              },
-              update: {
-                ...signup,
-                shiftId: Number(shiftId),
-                userId: Number(userId),
-                ...(status === null ? {} : { status }),
-              },
-              include: {
-                shift: true,
-              },
-            });
-          },
-        ),
+            },
+            create: {
+              ...signup,
+              status: SignupStatus.PENDING,
+              shiftId: Number(shiftId),
+              userId: Number(userId),
+            },
+            update: {
+              ...signup,
+              shiftId: Number(shiftId),
+              userId: Number(userId),
+              ...(status === null ? {} : { status }),
+            },
+            include: {
+              shift: true,
+            },
+          });
+        }),
       ]);
 
       // Skip first transaction result for deleted count

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -7,7 +7,6 @@ import {
   DeleteShiftSignupDTO,
   ShiftSignupResponseDTO,
   UpdateShiftSignupRequestDTO,
-  UpsertDeleteShiftSignupsRequestDTO,
   UpsertShiftSignupDTO,
 } from "../../types";
 import logger from "../../utilities/logger";

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -201,7 +201,8 @@ class ShiftSignupService implements IShiftSignupService {
         ),
       ]);
 
-      return newShiftSignups.map((newShiftSignup) => {
+      // Skip first transaction result for deleted count
+      return newShiftSignups.slice(1).map((newShiftSignup) => {
         const signup = newShiftSignup as Signup & {
           shift: Shift;
         };

--- a/backend/services/interfaces/shiftSignupService.ts
+++ b/backend/services/interfaces/shiftSignupService.ts
@@ -3,6 +3,7 @@ import {
   CreateShiftSignupDTO,
   ShiftSignupResponseDTO,
   UpdateShiftSignupRequestDTO,
+  UpsertDeleteShiftSignupsRequestDTO,
 } from "../../types";
 
 interface IShiftSignupService {
@@ -29,6 +30,16 @@ interface IShiftSignupService {
     userId: string,
     shiftSignup: UpdateShiftSignupRequestDTO,
   ): Promise<ShiftSignupResponseDTO>;
+
+  /**
+   * Bulk upsert and delete sign ups for shifts
+   * @param upsertDeleteshiftSignups array of UpsertShiftSignupDTOs and DeleteShiftSignupDTOs
+   * @returns an array of ShiftSignupResponseDTO
+   * @throws Error if any of the shifts signups cannot be created
+   */
+  upsertDeleteShiftSignups(
+    upsertDeleteShiftSignups: UpsertDeleteShiftSignupsRequestDTO,
+  ): Promise<ShiftSignupResponseDTO[]>;
 
   /**
    * Gets all shifts the user has signed up for

--- a/backend/services/interfaces/shiftSignupService.ts
+++ b/backend/services/interfaces/shiftSignupService.ts
@@ -1,9 +1,10 @@
 import { SignupStatus } from "@prisma/client";
 import {
   CreateShiftSignupDTO,
+  DeleteShiftSignupDTO,
   ShiftSignupResponseDTO,
   UpdateShiftSignupRequestDTO,
-  UpsertDeleteShiftSignupsRequestDTO,
+  UpsertShiftSignupDTO,
 } from "../../types";
 
 interface IShiftSignupService {
@@ -33,12 +34,14 @@ interface IShiftSignupService {
 
   /**
    * Bulk upsert and delete sign ups for shifts
-   * @param upsertDeleteshiftSignups array of UpsertShiftSignupDTOs and DeleteShiftSignupDTOs
+   * @param upsertShiftSignups array of UpsertShiftSignupDTOs for request
+   * @param deleteShiftSignups array of DeleteShiftSignupDTOs for request
    * @returns an array of ShiftSignupResponseDTO
    * @throws Error if any of the shifts signups cannot be created
    */
   upsertDeleteShiftSignups(
-    upsertDeleteShiftSignups: UpsertDeleteShiftSignupsRequestDTO,
+    upsertShiftSignups: UpsertShiftSignupDTO[],
+    deleteShiftSignups: DeleteShiftSignupDTO[],
   ): Promise<ShiftSignupResponseDTO[]>;
 
   /**

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -132,6 +132,20 @@ export type ShiftSignupDTO = {
 
 export type CreateShiftSignupDTO = Omit<ShiftSignupDTO, "status">;
 
+export type UpsertShiftSignupDTO = CreateShiftSignupDTO & {
+  status: ShiftSignupStatus | null;
+};
+
+export type DeleteShiftSignupDTO = Omit<
+  ShiftSignupDTO,
+  "numVolunteers" | "note" | "status"
+>;
+
+export type UpsertDeleteShiftSignupsRequestDTO = {
+  upsertShiftSignups: UpsertShiftSignupDTO[];
+  deleteShiftSignups: DeleteShiftSignupDTO[];
+};
+
 export type UpdateShiftSignupRequestDTO = Omit<
   ShiftSignupDTO,
   "shiftId" | "userId"

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -108,14 +108,23 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
             // Submit the selected shifts
             console.log(shiftSignups);
             console.log(signupNotes);
+            console.log(shiftsByPosting);
 
             // Assume Num volunteers would be one...
             // TODO: Merge data from shiftSignups and signupNotes together to pass into query
             const graphQLResult = await submitSignups({
               variables: {
                 upsertDeleteShifts: {
-                  upsertShiftSignups: [],
-                  deleteShiftSignups: [],
+                  upsertShiftSignups: shiftSignups.map((signup) => {
+                    const { id: shiftId } = signup;
+                    return {
+                      shiftId,
+                      userId: "1", // TODO: Replace with userID from me query or cookie
+                      note: "",
+                      numVolunteers: 0, // TODO: Replace with actual numVolunteer or make optional if allowed
+                    } as SignupRequestDTO;
+                  }),
+                  deleteShiftSignups: [], // Here, we want a new init state for existing signups to get deleted shifts
                 },
               },
             });

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -26,7 +26,7 @@ const SHIFTS_BY_POSTING = gql`
 
 // TODO: Remove redundancy from other pages
 const POSTING = gql`
-  query VolunteerPostingDetails_Posting($id: ID!) {
+  query VolunteerPostingAvailabilitiesDetails_Posting($id: ID!) {
     posting(id: $id) {
       title
       description
@@ -50,8 +50,10 @@ const POSTING = gql`
 // WE pass the user id from our current session token
 // TODO: Make this pass in a array of DTO
 const SUBMIT_SIGNUPS = gql`
-  mutation VolunteerShiftSignup($shiftId: ID!, userId: ID!, numVolunteers: Int!, note: String!) {
-    createShiftSignups(shifts: {shiftId: $shiftId, userId: $userId, numVolunteers: $numVolunteers, note: $note}) {
+  mutation VolunteerPostingAvailabilities_SubmitSignups(
+    $upsertDeleteShifts: UpsertDeleteShiftSignupRequestDTO!
+  ) {
+    upsertDeleteShiftSignups(upsertDeleteShifts: $upsertDeleteShifts) {
       status
     }
   }
@@ -107,13 +109,13 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
             console.log(shiftSignups);
             console.log(signupNotes);
 
+            // Assume Num volunteers would be one...
             // TODO: Merge data from shiftSignups and signupNotes together to pass into query
             const graphQLResult = await submitSignups({
-              // TODO: Fix variable passed in
               variables: {
-                shifts: {
-                  shiftSignups,
-                  signupNotes,
+                upsertDeleteShifts: {
+                  upsertShiftSignups: [],
+                  deleteShiftSignups: [],
                 },
               },
             });

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -1,16 +1,13 @@
 import React, { useState } from "react";
 import { Box, Button, Flex, Spacer, Spinner, Text } from "@chakra-ui/react";
 
-import { gql, useMutation, useQuery } from "@apollo/client";
+import { gql, useQuery } from "@apollo/client";
 import { Redirect, useHistory, useParams } from "react-router-dom";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import VolunteerAvailabilityTable from "../../../volunteer/shifts/VolunteerAvailabilityTable";
 import { ShiftResponseDTO } from "../../../../types/api/ShiftTypes";
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
-import {
-  SignupRequestDTO,
-  SignupResponseDTO,
-} from "../../../../types/api/SignupTypes";
+import { SignupRequestDTO } from "../../../../types/api/SignupTypes";
 
 // TODO: A filter should be added to the backend, currently, no filter is supported
 const SHIFTS_BY_POSTING = gql`
@@ -26,7 +23,7 @@ const SHIFTS_BY_POSTING = gql`
 
 // TODO: Remove redundancy from other pages
 const POSTING = gql`
-  query VolunteerPostingAvailabilitiesDetails_Posting($id: ID!) {
+  query VolunteerPostingDetails_Posting($id: ID!) {
     posting(id: $id) {
       title
       description
@@ -47,18 +44,6 @@ const POSTING = gql`
   }
 `;
 
-// WE pass the user id from our current session token
-// TODO: Make this pass in a array of DTO
-const SUBMIT_SIGNUPS = gql`
-  mutation VolunteerPostingAvailabilities_SubmitSignups(
-    $upsertDeleteShifts: UpsertDeleteShiftSignupRequestDTO!
-  ) {
-    upsertDeleteShiftSignups(upsertDeleteShifts: $upsertDeleteShifts) {
-      status
-    }
-  }
-`;
-
 const VolunteerPostingAvailabilities = (): React.ReactElement => {
   const { id } = useParams<{ id: string }>();
   const { loading: isShiftsLoading, data: { shiftsByPosting } = {} } = useQuery(
@@ -75,12 +60,8 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
     variables: { id },
     fetchPolicy: "cache-and-network",
   });
-
-  const [submitSignups] = useMutation<{ submitSignups: SignupResponseDTO }>(
-    SUBMIT_SIGNUPS,
-  );
-
   const history = useHistory();
+  // TODO: Use these state of selected shifts + notes for submission
   const [shiftSignups, setShiftSignups] = useState<ShiftResponseDTO[]>([]);
   const [signupNotes, setSignupNotes] = useState<SignupRequestDTO[]>([]);
 
@@ -104,32 +85,10 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
         <Text textStyle="display-large">Select your Availability</Text>
         <Spacer />
         <Button
-          onClick={async () => {
+          onClick={() => {
             // Submit the selected shifts
             console.log(shiftSignups);
             console.log(signupNotes);
-            console.log(shiftsByPosting);
-
-            // Assume Num volunteers would be one...
-            // TODO: Merge data from shiftSignups and signupNotes together to pass into query
-            const graphQLResult = await submitSignups({
-              variables: {
-                upsertDeleteShifts: {
-                  upsertShiftSignups: shiftSignups.map((signup) => {
-                    const { id: shiftId } = signup;
-                    return {
-                      shiftId,
-                      userId: "1", // TODO: Replace with userID from me query or cookie
-                      note: "",
-                      numVolunteers: 0, // TODO: Replace with actual numVolunteer or make optional if allowed
-                    } as SignupRequestDTO;
-                  }),
-                  deleteShiftSignups: [], // Here, we want a new init state for existing signups to get deleted shifts
-                },
-              },
-            });
-
-            // TODO: Do something after submission (move on to some page?)...
           }}
         >
           Submit

--- a/frontend/src/types/api/SignupTypes.ts
+++ b/frontend/src/types/api/SignupTypes.ts
@@ -11,4 +11,9 @@ export type SignupRequestDTO = Omit<
   "id" | "numVolunteers" | "userId"
 >;
 
+export type DeleteSignupRequestDTO = Omit<
+  SignupDTO,
+  "id" | "numVolunteers" | "note"
+>;
+
 export type SignupResponseDTO = SignupDTO;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #258


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add mutation call that does delete then upsert on signup shifts
* New mutation call has new types added

NOTE: Only the backend mutation is completed, not integrated into client at the moment.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create new signups
2. Use the new mutation call to update and delete some signups in the same graphql mutation

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness
* New Typing


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
