### PR TITLE
Load initial create posting values from context

### DIFF
--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -33,6 +33,7 @@ import {
   ADMIN_POSTING_CREATE_BASIC_INFO_ROLE_DESCRIPTION_PLACEHOLDER,
   ADMIN_POSTING_CREATE_BASIC_INFO_SKILLS_TOOLTIP,
 } from "../../../constants/Copy";
+import PostingContext from "../../../contexts/admin/PostingContext";
 import PostingContextDispatcherContext from "../../../contexts/admin/PostingContextDispatcherContext";
 
 import { BranchDTO, BranchResponseDTO } from "../../../types/api/BranchTypes";
@@ -73,6 +74,15 @@ const ERROR_MESSAGE_HEIGHT = "35px";
 const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
   navigateToNext,
 }: CreatePostingBasicInfoProps): React.ReactElement => {
+  const {
+    branch: branchFromCtx,
+    skills: skillsFromCtx,
+    employees: employeesFromCtx,
+    title: titleFromCtx,
+    description: descriptionFromCtx,
+    autoClosingDate: autoClosingDateFromCtx,
+    numVolunteers: numVolunteersFromCtx,
+  } = useContext(PostingContext);
   const dispatchPostingUpdate = useContext(PostingContextDispatcherContext);
 
   // #region state variables
@@ -81,14 +91,22 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
   const [employeeOptions, setEmployeeOptions] = useState<EmployeeUserDTO[]>([]);
 
   const [selectedBranch, setSelectedBranch] = useState<string | undefined>(
-    undefined,
+    branchFromCtx.id || undefined,
   );
-  const [numVolunteers, setNumVolunteers] = useState<number>(1);
-  const [title, setTitle] = useState<string>("");
-  const [autoClosingDate, setAutoClosingDate] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
-  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
-  const [selectedEmployees, setSelectedEmployees] = useState<string[]>([]);
+  const [numVolunteers, setNumVolunteers] = useState<number>(
+    numVolunteersFromCtx,
+  );
+  const [title, setTitle] = useState<string>(titleFromCtx);
+  const [autoClosingDate, setAutoClosingDate] = useState<string>(
+    autoClosingDateFromCtx,
+  );
+  const [description, setDescription] = useState<string>(descriptionFromCtx);
+  const [selectedSkills, setSelectedSkills] = useState<string[]>(
+    skillsFromCtx.map((skill) => skill.id),
+  );
+  const [selectedEmployees, setSelectedEmployees] = useState<string[]>(
+    employeesFromCtx.map((employee) => employee.id),
+  );
 
   const [branchError, setBranchError] = useState(false);
   const [titleError, setTitleError] = useState(false);
@@ -382,7 +400,6 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
             </HStack>
             <FormControl isRequired isInvalid={descriptionError}>
               <FormLabel textStyle="body-regular">Role Description</FormLabel>
-              {/* TODO: replace with RichTextField from Draft.js */}
               <RichTextField
                 initialContent={description}
                 defaultText={
@@ -446,7 +463,8 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                       mr={4}
                       mb={2}
                     >
-                      {getOptionNameFromId(skillOptions, skillId)}
+                      {skillOptions.length > 0 &&
+                        getOptionNameFromId(skillOptions, skillId)}
                       <TagCloseButton
                         onClick={() => handleSkillRemoval(skillId)}
                       />
@@ -463,7 +481,8 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                           mr={2}
                           mb={2}
                         >
-                          {getOptionNameFromId(skillOptions, skillId)}
+                          {skillOptions.length > 0 &&
+                            getOptionNameFromId(skillOptions, skillId)}
                           <TagCloseButton
                             onClick={() => handleSkillRemoval(skillId)}
                           />
@@ -511,13 +530,16 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                       mb={2}
                     >
                       <Avatar size="xs" mr={1} bg="violet" />
-                      {getOptionNameFromId(
-                        employeeOptions.map(({ id, firstName, lastName }) => ({
-                          id,
-                          name: `${firstName} ${lastName}`,
-                        })),
-                        employeeId,
-                      )}
+                      {employeeOptions.length > 0 &&
+                        getOptionNameFromId(
+                          employeeOptions.map(
+                            ({ id, firstName, lastName }) => ({
+                              id,
+                              name: `${firstName} ${lastName}`,
+                            }),
+                          ),
+                          employeeId,
+                        )}
                       <TagCloseButton
                         onClick={() => handleEmployeeRemoval(employeeId)}
                       />
@@ -535,15 +557,16 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                           mb={2}
                         >
                           <Avatar size="xs" mr={1} bg="violet" />
-                          {getOptionNameFromId(
-                            employeeOptions.map(
-                              ({ id, firstName, lastName }) => ({
-                                id,
-                                name: `${firstName} ${lastName}`,
-                              }),
-                            ),
-                            employeeId,
-                          )}
+                          {employeeOptions.length > 0 &&
+                            getOptionNameFromId(
+                              employeeOptions.map(
+                                ({ id, firstName, lastName }) => ({
+                                  id,
+                                  name: `${firstName} ${lastName}`,
+                                }),
+                              ),
+                              employeeId,
+                            )}
                           <TagCloseButton
                             onClick={() => handleEmployeeRemoval(employeeId)}
                           />

--- a/frontend/src/components/admin/posting/CreatePostingShifts.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingShifts.tsx
@@ -19,6 +19,7 @@ import {
   ADMIN_POSTING_CREATE_SCHEDULING_TIME_SLOTS,
   ADMIN_POSTING_CREATE_SHIFTS_TIME,
 } from "../../../constants/Copy";
+import PostingContext from "../../../contexts/admin/PostingContext";
 import PostingContextDispatcherContext from "../../../contexts/admin/PostingContextDispatcherContext";
 import WeekViewShiftCalendar from "../ShiftCalendar/WeekViewShiftCalendar";
 import { Event } from "../../../types/CalendarTypes";
@@ -28,6 +29,7 @@ import {
   getISOStringDateTime,
   getNextSunday,
   getPreviousSunday,
+  getUTCDateForDateTimeString,
 } from "../../../utils/DateTimeUtils";
 
 type CreatePostingShiftsProps = {
@@ -39,15 +41,27 @@ const CreatePostingShifts: React.FC<CreatePostingShiftsProps> = ({
   navigateBack,
   navigateToNext,
 }: CreatePostingShiftsProps): React.ReactElement => {
+  const {
+    startDate: startDateFromCtx,
+    endDate: endDateFromCtx,
+    times: timesFromCtx,
+    recurrenceInterval: recurrenceIntervalFromCtx,
+  } = useContext(PostingContext);
   const dispatchPostingUpdate = useContext(PostingContextDispatcherContext);
 
-  const [startDate, setStartDate] = useState<string>("");
-  const [endDate, setEndDate] = useState<string>("");
+  const [startDate, setStartDate] = useState<string>(startDateFromCtx);
+  const [endDate, setEndDate] = useState<string>(endDateFromCtx);
   const [
     recurrenceInterval,
     setRecurrenceInterval,
-  ] = useState<RecurrenceInterval>("" as RecurrenceInterval);
-  const [events, setEvents] = useState<Event[]>([]);
+  ] = useState<RecurrenceInterval>(recurrenceIntervalFromCtx);
+  const [events, setEvents] = useState<Event[]>(
+    timesFromCtx.map((time, index) => ({
+      id: String(index),
+      start: getUTCDateForDateTimeString(time.startTime),
+      end: getUTCDateForDateTimeString(time.endTime),
+    })),
+  );
   const [eventCount, setEventCount] = useState<number>(0);
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
 
@@ -186,6 +200,7 @@ const CreatePostingShifts: React.FC<CreatePostingShiftsProps> = ({
                   placeholder="How often will this occur?"
                   size="sm"
                   width="425px"
+                  value={recurrenceInterval}
                   onChange={(e) =>
                     setRecurrenceInterval(e.target.value as RecurrenceInterval)
                   }

--- a/frontend/src/components/admin/posting/CreatePostingShifts.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingShifts.tsx
@@ -51,10 +51,9 @@ const CreatePostingShifts: React.FC<CreatePostingShiftsProps> = ({
 
   const [startDate, setStartDate] = useState<string>(startDateFromCtx);
   const [endDate, setEndDate] = useState<string>(endDateFromCtx);
-  const [
-    recurrenceInterval,
-    setRecurrenceInterval,
-  ] = useState<RecurrenceInterval>(recurrenceIntervalFromCtx);
+  const [recurrenceInterval, setRecurrenceInterval] = useState<
+    RecurrenceInterval | ""
+  >(recurrenceIntervalFromCtx);
   const [events, setEvents] = useState<Event[]>(
     timesFromCtx.map((time, index) => ({
       id: String(index),

--- a/frontend/src/contexts/admin/PostingContext.ts
+++ b/frontend/src/contexts/admin/PostingContext.ts
@@ -24,7 +24,7 @@ export const DEFAULT_POSTING_CONTEXT = {
       endTime: "2022-02-06T13:30",
     },
   ],
-  recurrenceInterval: "NONE" as RecurrenceInterval,
+  recurrenceInterval: "" as RecurrenceInterval,
 };
 
 const PostingContext = createContext<PostingContextType>(

--- a/frontend/src/contexts/admin/PostingContext.ts
+++ b/frontend/src/contexts/admin/PostingContext.ts
@@ -1,10 +1,6 @@
 import { createContext } from "react";
 import { PostingContextType } from "../../types/PostingContextTypes";
-import {
-  PostingStatus,
-  PostingType,
-  RecurrenceInterval,
-} from "../../types/PostingTypes";
+import { PostingStatus, PostingType } from "../../types/PostingTypes";
 
 export const DEFAULT_POSTING_CONTEXT = {
   branch: { id: "", name: "" },
@@ -24,7 +20,7 @@ export const DEFAULT_POSTING_CONTEXT = {
       endTime: "2022-02-06T13:30",
     },
   ],
-  recurrenceInterval: "" as RecurrenceInterval,
+  recurrenceInterval: "" as const,
 };
 
 const PostingContext = createContext<PostingContextType>(

--- a/frontend/src/types/PostingContextTypes.ts
+++ b/frontend/src/types/PostingContextTypes.ts
@@ -21,7 +21,7 @@ export type PostingContextType = {
   autoClosingDate: string;
   numVolunteers: number;
   times: Shift[];
-  recurrenceInterval: RecurrenceInterval;
+  recurrenceInterval: RecurrenceInterval | "";
 };
 
 export type PostingContextAction =


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #233 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Set initial values in create basic info and shift pages to be values from the posting context
* Note context is updated on "Next", so previous values can only be retrieved if "Next" was clicked prior to navigating away

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click preview deploy link
2. Navigate to create posting page
3. Enter info on each page and test navigating forward/back with the "Next" and "Back" buttons, the previously entered data should be preserved


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Does it work?
* See comments


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
