### PR TITLE
Link posting cards to details and submit availabilities pages

### DIFF
--- a/frontend/src/components/common/PostingDetails.tsx
+++ b/frontend/src/components/common/PostingDetails.tsx
@@ -17,12 +17,13 @@ import RichTextDisplay from "./RichText/RichTextDisplay";
 
 type PostingDetailsProps = {
   postingDetails: PostingResponseDTO;
-  showFooterButton: boolean;
+  /* only render footer button if onClick handler is supplied */
+  footerButtonOnClick?: () => void;
 };
 
 const PostingDetails = ({
   postingDetails,
-  showFooterButton,
+  footerButtonOnClick,
 }: PostingDetailsProps): React.ReactElement => {
   return (
     <Box p={6} w="full">
@@ -81,7 +82,9 @@ const PostingDetails = ({
           <Text textStyle="caption" color="text.gray">
             Deadline: {formatDateStringYear(postingDetails.autoClosingDate)}
           </Text>
-          {showFooterButton ? <Button>Submit availability</Button> : null}
+          {footerButtonOnClick && (
+            <Button onClick={footerButtonOnClick}>Submit availability</Button>
+          )}
         </HStack>
       </VStack>
     </Box>

--- a/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
+++ b/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
@@ -59,12 +59,7 @@ const AdminPostingDetails = (): React.ReactElement => {
           centerContent
           borderRadius={10}
         >
-          {postingDetails ? (
-            <PostingDetails
-              postingDetails={postingDetails}
-              showFooterButton={false}
-            />
-          ) : null}
+          {postingDetails && <PostingDetails postingDetails={postingDetails} />}
         </Container>
       </VStack>
     </Box>

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
@@ -2,9 +2,18 @@ import React from "react";
 import { VStack, HStack, Box, Container, Button } from "@chakra-ui/react";
 
 import { gql, useQuery } from "@apollo/client";
-import { useParams, Redirect } from "react-router-dom";
+import {
+  generatePath,
+  useHistory,
+  useParams,
+  Redirect,
+} from "react-router-dom";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import PostingDetails from "../../../common/PostingDetails";
+import {
+  VOLUNTEER_POSTING_AVAILABILITIES,
+  VOLUNTEER_POSTINGS_PAGE,
+} from "../../../../constants/Routes";
 
 const POSTING = gql`
   query VolunteerPostingDetails_Posting($id: ID!) {
@@ -29,6 +38,7 @@ const POSTING = gql`
 `;
 
 const VolunteerPostingDetails = (): React.ReactElement => {
+  const history = useHistory();
   const { id } = useParams<{ id: string }>();
   const { loading, data: { posting: postingDetails } = {} } = useQuery(
     POSTING,
@@ -38,6 +48,11 @@ const VolunteerPostingDetails = (): React.ReactElement => {
     },
   );
 
+  const navigateToSubmitAvailabilities = () => {
+    const route = generatePath(VOLUNTEER_POSTING_AVAILABILITIES, { id });
+    history.push(route);
+  };
+
   return !loading && !postingDetails ? (
     <Redirect to="/not-found" />
   ) : (
@@ -45,10 +60,16 @@ const VolunteerPostingDetails = (): React.ReactElement => {
       <VStack>
         <Container pt={0} pb={4} px={0} maxW="container.xl">
           <HStack justifyContent="space-between">
-            <Button leftIcon={<ChevronLeftIcon />} variant="link">
+            <Button
+              leftIcon={<ChevronLeftIcon />}
+              variant="link"
+              onClick={() => history.push(VOLUNTEER_POSTINGS_PAGE)}
+            >
               Back to volunteer postings
             </Button>
-            <Button>Submit availability</Button>
+            <Button onClick={navigateToSubmitAvailabilities}>
+              Submit availability
+            </Button>
           </HStack>
         </Container>
 
@@ -59,7 +80,10 @@ const VolunteerPostingDetails = (): React.ReactElement => {
           borderRadius={10}
         >
           {postingDetails ? (
-            <PostingDetails postingDetails={postingDetails} showFooterButton />
+            <PostingDetails
+              postingDetails={postingDetails}
+              footerButtonOnClick={navigateToSubmitAvailabilities}
+            />
           ) : null}
         </Container>
       </VStack>

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -1,7 +1,12 @@
 import React, { useState, useLayoutEffect } from "react";
+import { generatePath, useHistory } from "react-router-dom";
 import { gql, useQuery } from "@apollo/client";
 import { Box, HStack, Select, Text } from "@chakra-ui/react";
 
+import {
+  VOLUNTEER_POSTING_AVAILABILITIES,
+  VOLUNTEER_POSTING_DETAILS,
+} from "../../../../constants/Routes";
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import { dateInRange } from "../../../../utils/DateTimeUtils";
 import { FilterType } from "../../../../types/DateFilterTypes";
@@ -36,6 +41,7 @@ const POSTINGS = gql`
 `;
 
 const VolunteerPostingsPage = (): React.ReactElement => {
+  const history = useHistory();
   const [postings, setPostings] = useState<Posting[] | null>(null);
   const [unfilteredPostings, setUnfilteredPostings] = useState<
     Posting[] | null
@@ -70,6 +76,16 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         break;
     }
   }, [filter, unfilteredPostings]);
+
+  const navigateToDetails = (id: string) => {
+    const route = generatePath(VOLUNTEER_POSTING_DETAILS, { id });
+    history.push(route);
+  };
+
+  const navigateToSubmitAvailabilities = (id: string) => {
+    const route = generatePath(VOLUNTEER_POSTING_AVAILABILITIES, { id });
+    history.push(route);
+  };
 
   const changeFilter = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value: FilterType = e.target.value as FilterType;
@@ -133,6 +149,10 @@ const VolunteerPostingsPage = (): React.ReactElement => {
                   autoClosingDate={posting.autoClosingDate}
                   description={posting.description}
                   branchName={posting.branch.name}
+                  navigateToDetails={() => navigateToDetails(posting.id)}
+                  navigateToSubmitAvailabilities={() =>
+                    navigateToSubmitAvailabilities(posting.id)
+                  }
                 />
               </Box>
             ))
@@ -155,6 +175,10 @@ const VolunteerPostingsPage = (): React.ReactElement => {
                   autoClosingDate={posting.autoClosingDate}
                   description={posting.description}
                   branchName={posting.branch.name}
+                  navigateToDetails={() => navigateToDetails(posting.id)}
+                  navigateToSubmitAvailabilities={() =>
+                    navigateToSubmitAvailabilities(posting.id)
+                  }
                 />
               </Box>
             ))

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -24,6 +24,8 @@ type PostingCardProps = {
   endDate: string;
   autoClosingDate: string;
   branchName: string;
+  navigateToDetails: () => void;
+  navigateToSubmitAvailabilities: () => void;
 };
 
 const PostingCard = ({
@@ -35,6 +37,8 @@ const PostingCard = ({
   endDate,
   autoClosingDate,
   branchName,
+  navigateToDetails,
+  navigateToSubmitAvailabilities,
 }: PostingCardProps): React.ReactElement => {
   return (
     <Box
@@ -79,8 +83,12 @@ const PostingCard = ({
             Deadline: {formatDateStringYear(autoClosingDate)}
           </Text>
           <ButtonGroup spacing="10px" size="md">
-            <Button variant="ghost">View Details</Button>
-            <Button variant="solid">Submit Availability</Button>
+            <Button variant="ghost" onClick={navigateToDetails}>
+              View Details
+            </Button>
+            <Button variant="solid" onClick={navigateToSubmitAvailabilities}>
+              Submit Availability
+            </Button>
           </ButtonGroup>
         </HStack>
       </VStack>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #255 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* In addition to posting card links, links also added for posting details pages
* Knowledge of routing is kept at the page-level and passed into components as props - feedback on this approach is welcome


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click on the preview deploy link
2. Navigate to `/volunteer/postings` and check that the posting details and submit availabilities links on the cards work
3. Check links on posting details pages (`/volunteer/posting/:id` and `/admin/posting/:id`)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Where does the routing responsibility belong?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
