### PR TITLE
Redirect to posting details page and display success toast upon submitting availability

### DIFF
--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from "react";
-import { Box, Button, Flex, Spacer, Spinner, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Flex,
+  Spacer,
+  Spinner,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
 
 import { gql, useQuery } from "@apollo/client";
 import { Redirect, useHistory, useParams } from "react-router-dom";
@@ -61,6 +69,7 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
     fetchPolicy: "cache-and-network",
   });
   const history = useHistory();
+  const toast = useToast();
   // TODO: Use these state of selected shifts + notes for submission
   const [shiftSignups, setShiftSignups] = useState<ShiftResponseDTO[]>([]);
   const [signupNotes, setSignupNotes] = useState<SignupRequestDTO[]>([]);
@@ -89,6 +98,15 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
             // Submit the selected shifts
             console.log(shiftSignups);
             console.log(signupNotes);
+
+            toast({
+              title: "Availability Submitted",
+              description: "Your availability has been submitted for review.",
+              status: "success",
+              duration: 5000,
+              isClosable: true,
+            });
+            history.push(`/volunteer/posting/${id}`);
           }}
         >
           Submit


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #257 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added redirect after submission of `VOLUNTEER_POSTING_AVAILABILITIES` page
* Displayed success toast on `VOLUNTEER_POSTING_DETAILS` page
* Research was asked to be done on persisting the toast, but it looks like it's natively supported by Chakra UI - nothing special had to be done.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `/volunteer/posting/:id/availabilities`
2. Click submit
3. Ensure redirect occurs and success toast is visible


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The functionality in steps to test. It is a pretty simple PR


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
