### PR TITLE
Implement monthly calendar header

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -98,10 +98,9 @@ const MonthViewShiftCalendar = ({
 
   const getEventsInMonth = (): MonthEvent[] => {
     const selectedMonthString = moment(selectedMonth).format("YYYY-MM");
-    const selectedMonthEvents = sortedEvents.filter((event) => {
+    return sortedEvents.filter((event) => {
       return moment(event.start).format("YYYY-MM") === selectedMonthString;
     });
-    return selectedMonthEvents;
   };
 
   return sortedEvents && sortedEvents.length > 0 ? (

--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -98,9 +98,10 @@ const MonthViewShiftCalendar = ({
 
   const getEventsInMonth = (): MonthEvent[] => {
     const selectedMonthString = moment(selectedMonth).format("YYYY-MM");
-    return sortedEvents.filter((event) => {
+    const selectedMonthEvents = sortedEvents.filter((event) => {
       return moment(event.start).format("YYYY-MM") === selectedMonthString;
     });
+    return selectedMonthEvents;
   };
 
   return sortedEvents && sortedEvents.length > 0 ? (
@@ -167,7 +168,10 @@ const MonthViewShiftCalendar = ({
           Next month
         </Button>
       </Flex>
-      <MonthlyViewShiftCalendar events={getEventsInMonth()} />
+      <MonthlyViewShiftCalendar
+        events={getEventsInMonth()}
+        initialDate={selectedMonth}
+      />
     </Box>
   ) : (
     <Box>No events to display</Box>

--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -1,0 +1,177 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
+import { Box, Button, Flex, Select, Spacer } from "@chakra-ui/react";
+import moment from "moment";
+import React, { useEffect } from "react";
+import { MonthEvent } from "../../../types/CalendarTypes";
+import {
+  getFirstDayOfMonth,
+  getMonthDiff,
+  getMonthsInRange,
+} from "../../../utils/DateTimeUtils";
+import MonthlyViewShiftCalendar from "./MonthlyViewReadOnlyShiftCalendar";
+
+export const ADMIN_SHIFT_CALENDAR_TEST_EVENTS: MonthEvent[] = [
+  {
+    id: "1",
+    groupId: "unsaved",
+    start: new Date("2022-03-01 09:00:00 UTC"),
+    end: new Date("2022-03-01 10:00:00 UTC"),
+  },
+  {
+    id: "2",
+    groupId: "unsaved",
+    start: new Date("2022-07-01 10:00:00 UTC"),
+    end: new Date("2022-07-01 11:30:00 UTC"),
+  },
+  {
+    id: "3",
+    groupId: "saved",
+    start: new Date("2022-03-01 15:00:00 UTC"),
+    end: new Date("2022-03-01 17:00:00 UTC"),
+  },
+  {
+    id: "4",
+    groupId: "unsaved",
+    start: new Date("2022-06-02 17:15:00 UTC"),
+    end: new Date("2022-06-02 19:00:00 UTC"),
+  },
+  {
+    id: "5",
+    groupId: "saved",
+    start: new Date("2022-03-02 05:00:00 UTC"),
+    end: new Date("2022-03-02 13:00:00 UTC"),
+  },
+  {
+    id: "6",
+    groupId: "saved",
+    start: new Date("2022-03-14 14:00:00 UTC"),
+    end: new Date("2022-03-14 15:00:00 UTC"),
+  },
+  {
+    id: "7",
+    groupId: "unsaved",
+    start: new Date("2022-04-17 11:00:00 UTC"),
+    end: new Date("2022-04-17 13:00:00 UTC"),
+  },
+  {
+    id: "8",
+    groupId: "saved",
+    start: new Date("2022-07-12 11:00:00 UTC"),
+    end: new Date("2022-07-12 13:00:00 UTC"),
+  },
+  {
+    id: "9",
+    groupId: "saved",
+    start: new Date("2022-04-19 09:00:00 UTC"),
+    end: new Date("2022-04-19 11:00:00 UTC"),
+  },
+  {
+    id: "10",
+    groupId: "saved",
+    start: new Date("2022-06-05 13:00:00 UTC"),
+    end: new Date("2022-06-05 15:00:00 UTC"),
+  },
+];
+
+type MonthViewShiftCalendarProps = {
+  events: MonthEvent[];
+};
+
+const MonthViewShiftCalendar = ({
+  events,
+}: MonthViewShiftCalendarProps): React.ReactElement => {
+  const sortEvents = (unsortedEvents: MonthEvent[]): MonthEvent[] => {
+    return unsortedEvents.sort((a, b) => {
+      return moment(a.start).diff(moment(b.start));
+    });
+  };
+
+  // Current month to display, indicated by the first day of the month.
+  const [selectedMonth, setSelectedMonth] = React.useState<Date>(new Date());
+  const [sortedEvents, setSortedEvents] = React.useState<MonthEvent[]>([]);
+
+  useEffect(() => {
+    const sortedEventsList = sortEvents(events);
+    setSortedEvents(sortedEventsList);
+    setSelectedMonth(getFirstDayOfMonth(sortedEventsList[0].start));
+  }, [events]);
+
+  const getEventsInMonth = (): MonthEvent[] => {
+    const selectedMonthString = moment(selectedMonth).format("YYYY-MM");
+    return sortedEvents.filter((event) => {
+      return moment(event.start).format("YYYY-MM") === selectedMonthString;
+    });
+  };
+
+  return sortedEvents && sortedEvents.length > 0 ? (
+    <Box>
+      <Flex alignContent="center" px={25} py={25}>
+        <Button
+          variant="link"
+          leftIcon={<ChevronLeftIcon />}
+          disabled={
+            moment(selectedMonth).format("YYYY-MM") ===
+            moment(sortedEvents[0].start).format("YYYY-MM")
+          }
+          onClick={() => {
+            setSelectedMonth(
+              moment(selectedMonth).subtract(1, "month").toDate(),
+            );
+          }}
+        >
+          Previous month
+        </Button>
+        <Spacer />
+        <Select
+          width="33%"
+          _hover={{ bgColor: "gray.100" }}
+          value={getMonthDiff(sortedEvents[0].start, selectedMonth)}
+          onChange={(e) => {
+            setSelectedMonth(
+              moment(sortedEvents[0].start)
+                .add(e.target.value, "month")
+                .toDate(),
+            );
+          }}
+        >
+          {getMonthsInRange(
+            getFirstDayOfMonth(sortedEvents[0].start),
+            getFirstDayOfMonth(sortedEvents[sortedEvents.length - 1].start), // latest event
+          ).map((month) => {
+            return (
+              <option
+                key={month.toString()}
+                value={getMonthDiff(sortedEvents[0].start, month)}
+                color="gray.100"
+              >
+                {month.toLocaleString("default", { month: "long" })}{" "}
+                {month.getFullYear()}
+              </option>
+            );
+          })}
+        </Select>
+        <Spacer />
+        <Button
+          variant="link"
+          rightIcon={<ChevronRightIcon />}
+          disabled={
+            moment(selectedMonth).format("YYYY-MM") ===
+            moment(sortedEvents[sortedEvents.length - 1].start).format(
+              "YYYY-MM",
+            )
+          }
+          onClick={() => {
+            setSelectedMonth(moment(selectedMonth).add(1, "month").toDate());
+          }}
+        >
+          Next month
+        </Button>
+      </Flex>
+      <MonthlyViewShiftCalendar events={getEventsInMonth()} />
+    </Box>
+  ) : (
+    <Box>No events to display</Box>
+  );
+};
+
+export default MonthViewShiftCalendar;

--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -98,9 +98,10 @@ const MonthViewShiftCalendar = ({
 
   const getEventsInMonth = (): MonthEvent[] => {
     const selectedMonthString = moment(selectedMonth).format("YYYY-MM");
-    return sortedEvents.filter((event) => {
+    const selectedMonthEvents = sortedEvents.filter((event) => {
       return moment(event.start).format("YYYY-MM") === selectedMonthString;
     });
+    return selectedMonthEvents;
   };
 
   return sortedEvents && sortedEvents.length > 0 ? (

--- a/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import FullCalendar, {
   DayCellContentArg,
   EventContentArg,
@@ -7,66 +7,9 @@ import FullCalendar, {
 import dayGridPlugin from "@fullcalendar/daygrid";
 import { Box } from "@chakra-ui/react";
 
-import { Event, MonthEvent } from "../../../types/CalendarTypes";
+import { Event } from "../../../types/CalendarTypes";
 import colors from "../../../theme/colors";
 import "./Calendar.css";
-
-export const ADMIN_SHIFT_CALENDAR_TEST_EVENTS: MonthEvent[] = [
-  {
-    id: "1",
-    groupId: "unsaved",
-    start: new Date("2022-03-01 09:00:00 UTC"),
-    end: new Date("2022-03-01 10:00:00 UTC"),
-  },
-  {
-    id: "2",
-    groupId: "unsaved",
-    start: new Date("2022-03-01 10:00:00 UTC"),
-    end: new Date("2022-03-01 11:30:00 UTC"),
-  },
-  {
-    id: "3",
-    groupId: "saved",
-    start: new Date("2022-03-01 15:00:00 UTC"),
-    end: new Date("2022-03-01 17:00:00 UTC"),
-  },
-  {
-    id: "4",
-    groupId: "unsaved",
-    start: new Date("2022-03-01 17:15:00 UTC"),
-    end: new Date("2022-03-01 19:00:00 UTC"),
-  },
-  {
-    id: "5",
-    groupId: "saved",
-    start: new Date("2022-03-02 05:00:00 UTC"),
-    end: new Date("2022-03-02 13:00:00 UTC"),
-  },
-  {
-    id: "6",
-    groupId: "saved",
-    start: new Date("2022-03-14 14:00:00 UTC"),
-    end: new Date("2022-03-14 15:00:00 UTC"),
-  },
-  {
-    id: "7",
-    groupId: "unsaved",
-    start: new Date("2022-03-17 11:00:00 UTC"),
-    end: new Date("2022-03-17 13:00:00 UTC"),
-  },
-  {
-    id: "7",
-    groupId: "saved",
-    start: new Date("2022-03-17 09:00:00 UTC"),
-    end: new Date("2022-03-17 11:00:00 UTC"),
-  },
-  {
-    id: "7",
-    groupId: "unsaved",
-    start: new Date("2022-03-17 13:00:00 UTC"),
-    end: new Date("2022-03-17 15:00:00 UTC"),
-  },
-];
 
 // Events can be passed in any order (does not have to be sorted).
 // AdminShiftCalendar assumes that all events are in the same month.
@@ -77,6 +20,15 @@ type AdminShiftCalendarProps = {
 const MonthlyViewShiftCalendar = ({
   events,
 }: AdminShiftCalendarProps): React.ReactElement => {
+  const calendarRef = React.useRef<FullCalendar>(null);
+
+  useEffect(() => {
+    const calendarApi = calendarRef.current?.getApi();
+    if (calendarApi && events.length > 0) {
+      calendarApi.gotoDate(events[0].start);
+    }
+  });
+
   const displayCustomEvent = (content: EventContentArg) => {
     return (
       <>
@@ -123,8 +75,8 @@ const MonthlyViewShiftCalendar = ({
         initialDate={events.length > 0 ? events[0].start : new Date()}
         initialView="dayGridMonth"
         plugins={[dayGridPlugin]}
-        selectMirror
         selectable
+        ref={calendarRef}
         timeZone="UTC"
       />
     </Box>

--- a/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
@@ -15,17 +15,19 @@ import "./Calendar.css";
 // AdminShiftCalendar assumes that all events are in the same month.
 type AdminShiftCalendarProps = {
   events: Event[];
+  initialDate: Date;
 };
 
 const MonthlyViewShiftCalendar = ({
   events,
+  initialDate,
 }: AdminShiftCalendarProps): React.ReactElement => {
   const calendarRef = React.useRef<FullCalendar>(null);
 
   useEffect(() => {
     const calendarApi = calendarRef.current?.getApi();
-    if (calendarApi && events.length > 0) {
-      calendarApi.gotoDate(events[0].start);
+    if (calendarApi) {
+      calendarApi.gotoDate(initialDate);
     }
   });
 
@@ -72,7 +74,7 @@ const MonthlyViewShiftCalendar = ({
         }}
         fixedWeekCount={false}
         headerToolbar={false}
-        initialDate={events.length > 0 ? events[0].start : new Date()}
+        initialDate={initialDate}
         initialView="dayGridMonth"
         plugins={[dayGridPlugin]}
         selectable

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 import {
   Button as ChakraButton,
+  Container,
   HStack,
   Tab,
   TabList,
@@ -15,6 +16,9 @@ import RefreshCredentials from "../auth/RefreshCredentials";
 
 import * as Routes from "../../constants/Routes";
 import SampleContext from "../../contexts/SampleContext";
+import MonthViewShiftCalendar, {
+  ADMIN_SHIFT_CALENDAR_TEST_EVENTS,
+} from "../admin/ShiftCalendar/MonthViewShiftCalendar";
 
 type ButtonProps = { text: string; path: string };
 
@@ -184,6 +188,9 @@ const Default = (): React.ReactElement => {
       <div style={{ height: "2rem" }} />
       <TeamInfoDisplay />
       <DesignSystemDisplay />
+      <Container maxW="container.xl">
+        <MonthViewShiftCalendar events={ADMIN_SHIFT_CALENDAR_TEST_EVENTS} />
+      </Container>
     </div>
   );
 };

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 import {
   Button as ChakraButton,
-  Container,
   HStack,
   Tab,
   TabList,
@@ -16,9 +15,6 @@ import RefreshCredentials from "../auth/RefreshCredentials";
 
 import * as Routes from "../../constants/Routes";
 import SampleContext from "../../contexts/SampleContext";
-import MonthViewShiftCalendar, {
-  ADMIN_SHIFT_CALENDAR_TEST_EVENTS,
-} from "../admin/ShiftCalendar/MonthViewShiftCalendar";
 
 type ButtonProps = { text: string; path: string };
 
@@ -188,9 +184,6 @@ const Default = (): React.ReactElement => {
       <div style={{ height: "2rem" }} />
       <TeamInfoDisplay />
       <DesignSystemDisplay />
-      <Container maxW="container.xl">
-        <MonthViewShiftCalendar events={ADMIN_SHIFT_CALENDAR_TEST_EVENTS} />
-      </Container>
     </div>
   );
 };

--- a/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
@@ -15,9 +15,8 @@ import { AdminNavbarTabs, AdminPages } from "../../../../constants/Tabs";
 import AdminSchedulePageHeader from "../../../admin/schedule/AdminSchedulePageHeader";
 import AdminPostingScheduleHeader from "../../../admin/schedule/AdminPostingScheduleHeader";
 import ErrorModal from "../../../common/ErrorModal";
-import MonthlyViewShiftCalendar, {
-  ADMIN_SHIFT_CALENDAR_TEST_EVENTS,
-} from "../../../admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar";
+import MonthlyViewShiftCalendar from "../../../admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar";
+import { ADMIN_SHIFT_CALENDAR_TEST_EVENTS } from "../../../admin/ShiftCalendar/MonthViewShiftCalendar";
 import AdminScheduleTable, {
   TableTestData,
 } from "../../../admin/schedule/AdminScheduleTable";
@@ -138,6 +137,7 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
             />
             <MonthlyViewShiftCalendar
               events={ADMIN_SHIFT_CALENDAR_TEST_EVENTS}
+              initialDate={ADMIN_SHIFT_CALENDAR_TEST_EVENTS[0].start}
             />
           </Box>
           <Box w="400px" overflow="hidden">

--- a/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
@@ -15,8 +15,9 @@ import { AdminNavbarTabs, AdminPages } from "../../../../constants/Tabs";
 import AdminSchedulePageHeader from "../../../admin/schedule/AdminSchedulePageHeader";
 import AdminPostingScheduleHeader from "../../../admin/schedule/AdminPostingScheduleHeader";
 import ErrorModal from "../../../common/ErrorModal";
-import MonthlyViewShiftCalendar from "../../../admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar";
-import { ADMIN_SHIFT_CALENDAR_TEST_EVENTS } from "../../../admin/ShiftCalendar/MonthViewShiftCalendar";
+import MonthViewShiftCalendar, {
+  ADMIN_SHIFT_CALENDAR_TEST_EVENTS,
+} from "../../../admin/ShiftCalendar/MonthViewShiftCalendar";
 import AdminScheduleTable, {
   TableTestData,
 } from "../../../admin/schedule/AdminScheduleTable";
@@ -135,10 +136,7 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
                 setCurrentView(AdminScheduleViews.ReviewView)
               }
             />
-            <MonthlyViewShiftCalendar
-              events={ADMIN_SHIFT_CALENDAR_TEST_EVENTS}
-              initialDate={ADMIN_SHIFT_CALENDAR_TEST_EVENTS[0].start}
-            />
+            <MonthViewShiftCalendar events={ADMIN_SHIFT_CALENDAR_TEST_EVENTS} />
           </Box>
           <Box w="400px" overflow="hidden">
             <ScheduleSidePanel

--- a/frontend/src/utils/DateTimeUtils.ts
+++ b/frontend/src/utils/DateTimeUtils.ts
@@ -133,3 +133,39 @@ export const getWeekDiff = (start: Date, end: Date): number => {
     .startOf("week")
     .diff(moment(start).startOf("week").toDate(), "week", false);
 };
+
+/**
+ * get integer difference of months between 2 dates (end - start)
+ * @param  {Date} start
+ * @param  {Date} end
+ * @returns number
+ */
+export const getMonthDiff = (start: Date, end: Date): number => {
+  return moment(end)
+    .startOf("month")
+    .diff(moment(start).startOf("month").toDate(), "month", false);
+};
+
+/**
+ * get the first day of a month
+ */
+export const getFirstDayOfMonth = (date: Date): Date => {
+  return moment(date).startOf("month").toDate();
+};
+
+/**
+ * Gets all months within the range of startDate and endDate
+ * @param startDate the start date of the range
+ * @param endDate the end date of the range
+ * @returns an array of months in between startDate and endDate
+ */
+export const getMonthsInRange = (startDate: Date, endDate: Date): Date[] => {
+  const monthsInRange: Date[] = [];
+  let currentMonth = moment(startDate).startOf("month");
+  const endMonth = moment(endDate).endOf("month");
+  while (currentMonth.isBefore(endMonth)) {
+    monthsInRange.push(currentMonth.toDate());
+    currentMonth = currentMonth.add(1, "month");
+  }
+  return monthsInRange;
+};


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #178 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created a header for the monthly shift calendar that allows navigation between months.
* The header includes the following:
  * Next month button if there are shifts after this month
  * Previous month button if there are shifts before this month
  * Month dropdown to display each month with shifts
* As per discussions with @krystaltruong:
  * The header navigation will start at the earliest event (start date) by default.
  * If there is a month in between with no events, it will still be included in the navigation. (For example, May 2022 in `ADMIN_SHIFT_CALENDAR_TEST_EVENTS` is still displayed). 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to `http://localhost:3000/admin/schedule/posting/{id}` to see `ADMIN_SHIFT_CALENDAR_TEST_EVENTS` displayed.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Potential edge cases?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
