### PR TITLE
Create shifts with posting

### DIFF
--- a/backend/graphql/resolvers/postingResolvers.ts
+++ b/backend/graphql/resolvers/postingResolvers.ts
@@ -1,8 +1,15 @@
 import PostingService from "../../services/implementations/postingService";
 import IPostingService from "../../services/interfaces/postingService";
-import { PostingRequestDTO, PostingResponseDTO } from "../../types";
+import {
+  PostingRequestDTO,
+  PostingResponseDTO,
+  PostingWithShiftsRequestDTO,
+} from "../../types";
+import IShiftService from "../../services/interfaces/IShiftService";
+import ShiftService from "../../services/implementations/shiftService";
 
-const postingService: IPostingService = new PostingService();
+const shiftService: IShiftService = new ShiftService();
+const postingService: IPostingService = new PostingService(shiftService);
 
 const postingResolvers = {
   Query: {
@@ -19,7 +26,7 @@ const postingResolvers = {
   Mutation: {
     createPosting: async (
       _parent: undefined,
-      { posting }: { posting: PostingRequestDTO },
+      { posting }: { posting: PostingWithShiftsRequestDTO },
     ): Promise<PostingResponseDTO> => {
       const newPosting = await postingService.createPosting(posting);
       return newPosting;

--- a/backend/graphql/types/postingType.ts
+++ b/backend/graphql/types/postingType.ts
@@ -26,6 +26,22 @@ const postingType = gql`
     numVolunteers: Int!
   }
 
+  input PostingWithShiftsRequestDTO {
+    branchId: ID!
+    skills: [ID!]!
+    employees: [ID!]!
+    title: String!
+    type: PostingType!
+    status: PostingStatus!
+    description: String!
+    startDate: Date!
+    endDate: Date!
+    autoClosingDate: Date!
+    numVolunteers: Int!
+    recurrenceInterval: RecurrenceInterval!
+    times: [ShiftRequestDTO]!
+  }
+
   type PostingResponseDTO {
     id: ID!
     branch: BranchResponseDTO!
@@ -54,7 +70,7 @@ const postingType = gql`
   }
 
   extend type Mutation {
-    createPosting(posting: PostingRequestDTO!): PostingResponseDTO!
+    createPosting(posting: PostingWithShiftsRequestDTO!): PostingResponseDTO!
     updatePosting(id: ID!, posting: PostingRequestDTO!): PostingResponseDTO!
     deletePosting(id: ID!): ID!
   }

--- a/backend/services/interfaces/IShiftService.ts
+++ b/backend/services/interfaces/IShiftService.ts
@@ -1,11 +1,19 @@
 import {
   ShiftBulkRequestDTO,
+  ShiftDataWithoutPostingId,
   ShiftRequestDTO,
   ShiftResponseDTO,
   TimeBlock,
 } from "../../types";
 
 interface IShiftService {
+  /**
+   * Generate shift data in bulk
+   * @param shifts the shifts to be created
+   * @returns an array of TimeBlocks
+   * @throws Error if shift validation fails
+   */
+  bulkGenerateTimeBlocks(shifts: ShiftDataWithoutPostingId): TimeBlock[];
   /**
    * Get ShiftDTO associated with id
    * @param id shift's id

--- a/backend/services/interfaces/postingService.ts
+++ b/backend/services/interfaces/postingService.ts
@@ -1,4 +1,8 @@
-import { PostingRequestDTO, PostingResponseDTO } from "../../types";
+import {
+  PostingRequestDTO,
+  PostingResponseDTO,
+  PostingWithShiftsRequestDTO,
+} from "../../types";
 
 interface IPostingService {
   /**
@@ -22,7 +26,9 @@ interface IPostingService {
    * @returns a PostingDTO with the created posting's information
    * @throws Error if posting creation fails
    */
-  createPosting(posting: PostingRequestDTO): Promise<PostingResponseDTO>;
+  createPosting(
+    posting: PostingWithShiftsRequestDTO,
+  ): Promise<PostingResponseDTO>;
 
   /**
    * Update a posting.

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -116,7 +116,14 @@ export type ShiftBulkRequestDTO = {
   recurrenceInterval: RecurrenceInterval;
 };
 
+export type ShiftDataWithoutPostingId = Omit<ShiftBulkRequestDTO, "postingId">;
+
 export type ShiftResponseDTO = ShiftDTO;
+
+export type PostingWithShiftsRequestDTO = PostingRequestDTO & {
+  recurrenceInterval: RecurrenceInterval;
+  times: TimeBlock[];
+};
 
 export type ShiftSignupStatus =
   | "PENDING"

--- a/frontend/src/types/api/PostingTypes.ts
+++ b/frontend/src/types/api/PostingTypes.ts
@@ -1,6 +1,6 @@
 import { BranchResponseDTO } from "./BranchTypes";
 import { SkillResponseDTO } from "./SkillTypes";
-import { ShiftResponseDTO } from "./ShiftTypes";
+import { ShiftResponseDTO, RecurrenceInterval, TimeBlock } from "./ShiftTypes";
 import { EmployeeResponseDTO } from "./EmployeeTypes";
 
 export type PostingType = "INDIVIDUAL" | "GROUP";
@@ -23,6 +23,11 @@ export type PostingDTO = {
 };
 
 export type PostingRequestDTO = Omit<PostingDTO, "id">;
+
+export type PostingWithShiftsRequestDTO = PostingRequestDTO & {
+  recurrenceInterval: RecurrenceInterval;
+  times: TimeBlock[];
+};
 
 export type PostingResponseDTO = Omit<
   PostingDTO,


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #244 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created a new method called `bulkGenerateTimeBlocks` that will verify and create an array of TimeBlocks to be used creating a posting
* `CreatePosting` now generates shifts along with the posting
* Front end of the Create posting review page has been updated to match the modified endpoint


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a new posting (try recurring and non-recurring shifts) through the UI
2. After submitting, query for the posting and check that it was created properly with the associated shifts

```
query Postings {
  postings {
    id
    title
    description
    startDate
    endDate
    status
    shifts {
      startTime
      endTime
    }
  }
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
*  Shifts are generated with the same logic as before


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
