### PR TITLE
Update default numVolunteers to 1 in default posting context

### DIFF
--- a/frontend/src/contexts/admin/PostingContext.ts
+++ b/frontend/src/contexts/admin/PostingContext.ts
@@ -13,7 +13,7 @@ export const DEFAULT_POSTING_CONTEXT = {
   startDate: "",
   endDate: "",
   autoClosingDate: "",
-  numVolunteers: 0,
+  numVolunteers: 1,
   times: [
     {
       startTime: "2022-02-06T09:30",


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #282 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated the `numVolunteers` value to 1 in the default posting context
* "snap to default" behaviour in number input will ensure that user cannot set the value to 1


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click the preview deploy link
2. Go to the create posting page, verify that the initial number of volunteers shown is 1
3. Try to change the value to 0, verify that it is "snapped" to 0


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
