### PR TITLE
Fix num volunteers input for admin posting flow NaN bug

### DIFF
--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -93,8 +93,8 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
   const [selectedBranch, setSelectedBranch] = useState<string | undefined>(
     branchFromCtx.id || undefined,
   );
-  const [numVolunteers, setNumVolunteers] = useState<number>(
-    numVolunteersFromCtx,
+  const [numVolunteers, setNumVolunteers] = useState<string>(
+    String(numVolunteersFromCtx),
   );
   const [title, setTitle] = useState<string>(titleFromCtx);
   const [autoClosingDate, setAutoClosingDate] = useState<string>(
@@ -109,6 +109,7 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
   );
 
   const [branchError, setBranchError] = useState(false);
+  const [numVolunteersError, setNumVolunteersError] = useState(false);
   const [titleError, setTitleError] = useState(false);
   const [autoClosingDateError, setAutoClosingDateError] = useState(false);
   const [descriptionError, setDescriptionError] = useState(false);
@@ -266,6 +267,7 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
 
   const handleNext = () => {
     setBranchError(!selectedBranch);
+    setNumVolunteersError(Number.isNaN(parseInt(numVolunteers, 10)))
     setTitleError(!title);
     setAutoClosingDateError(!autoClosingDate);
     setDescriptionError(
@@ -280,11 +282,12 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
       autoClosingDate &&
       description &&
       selectedSkills &&
-      selectedEmployees
+      selectedEmployees &&
+      !Number.isNaN(parseInt(numVolunteers, 10))
     ) {
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       addBranch(selectedBranch!);
-      addNumVolunteers(numVolunteers);
+      addNumVolunteers(parseInt(numVolunteers, 10));
       addTitle(title);
       addAutoClosingDate(autoClosingDate);
       addDescription(description);
@@ -311,6 +314,7 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                 <Select
                   placeholder="Select option"
                   size="sm"
+                  mb={!branchError && numVolunteersError ? ERROR_MESSAGE_HEIGHT : "0px"}
                   value={selectedBranch}
                   onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
                     setSelectedBranch(e.target.value)
@@ -324,17 +328,17 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                 </Select>
                 <FormErrorMessage>Please select a branch.</FormErrorMessage>
               </FormControl>
-              <FormControl isRequired>
+              <FormControl isRequired isInvalid={numVolunteersError}>
                 <FormLabel textStyle="body-regular">
                   Total Number of Volunteers
                 </FormLabel>
                 <NumberInput
                   size="sm"
-                  mb={branchError ? ERROR_MESSAGE_HEIGHT : "0px"}
+                  mb={!numVolunteersError && branchError ? ERROR_MESSAGE_HEIGHT : "0px"}
                   value={numVolunteers}
                   min={1}
-                  onChange={(_valueAsString, valueAsNumber) =>
-                    setNumVolunteers(valueAsNumber)
+                  onChange={(valueString) => 
+                    setNumVolunteers(valueString)
                   }
                 >
                   <NumberInputField />
@@ -343,6 +347,7 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                     <NumberDecrementStepper />
                   </NumberInputStepper>
                 </NumberInput>
+                <FormErrorMessage>Please enter a valid number of volunteers.</FormErrorMessage>
               </FormControl>
             </HStack>
             <HStack spacing={7} w="full">

--- a/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingBasicInfo.tsx
@@ -267,7 +267,7 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
 
   const handleNext = () => {
     setBranchError(!selectedBranch);
-    setNumVolunteersError(Number.isNaN(parseInt(numVolunteers, 10)))
+    setNumVolunteersError(Number.isNaN(parseInt(numVolunteers, 10)));
     setTitleError(!title);
     setAutoClosingDateError(!autoClosingDate);
     setDescriptionError(
@@ -314,7 +314,11 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                 <Select
                   placeholder="Select option"
                   size="sm"
-                  mb={!branchError && numVolunteersError ? ERROR_MESSAGE_HEIGHT : "0px"}
+                  mb={
+                    !branchError && numVolunteersError
+                      ? ERROR_MESSAGE_HEIGHT
+                      : "0px"
+                  }
                   value={selectedBranch}
                   onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
                     setSelectedBranch(e.target.value)
@@ -334,12 +338,14 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                 </FormLabel>
                 <NumberInput
                   size="sm"
-                  mb={!numVolunteersError && branchError ? ERROR_MESSAGE_HEIGHT : "0px"}
+                  mb={
+                    !numVolunteersError && branchError
+                      ? ERROR_MESSAGE_HEIGHT
+                      : "0px"
+                  }
                   value={numVolunteers}
                   min={1}
-                  onChange={(valueString) => 
-                    setNumVolunteers(valueString)
-                  }
+                  onChange={(valueString) => setNumVolunteers(valueString)}
                 >
                   <NumberInputField />
                   <NumberInputStepper>
@@ -347,7 +353,9 @@ const CreatePostingBasicInfo: React.FC<CreatePostingBasicInfoProps> = ({
                     <NumberDecrementStepper />
                   </NumberInputStepper>
                 </NumberInput>
-                <FormErrorMessage>Please enter a valid number of volunteers.</FormErrorMessage>
+                <FormErrorMessage>
+                  Please enter a valid number of volunteers.
+                </FormErrorMessage>
               </FormControl>
             </HStack>
             <HStack spacing={7} w="full">


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #272


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed the input value to be a string and made sure to parse the string when clicking the `Next` button.
* If parse fails, then displays an error


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `http://localhost:3000/admin/posting/create/basic-info`
2. Try various values for num volunteers input and click Next button (check if behaviour seems correct)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Just the behaviour of the num volunteers input


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
