### PR TITLE
Rickson/content cuts off from role desc screen view on enter press

### DIFF
--- a/frontend/src/components/common/RichText/RichTextField.tsx
+++ b/frontend/src/components/common/RichText/RichTextField.tsx
@@ -305,7 +305,7 @@ const RichTextField: FunctionComponent<RichTextFieldProps> = (
   };
 
   return (
-    <VStack alignItems="flex-start">
+    <VStack alignItems="flex-start" w="full">
       <HStack h="32px">
         <Select
           ml="12px"
@@ -405,17 +405,17 @@ const RichTextField: FunctionComponent<RichTextFieldProps> = (
         borderWidth={editorBorderWidth}
         borderRadius="sm"
         borderColor={editorBorderColor}
-        overflowY="auto"
-        p="12px"
-        m="12px"
-        minH="200px"
-        maxH="200px"
+        p="5px"
         maxW="container.md"
         sx={{
           ...fontSizeObject,
           ".public-DraftEditorPlaceholder-root": {
             display: showPlaceHolder,
             fontSize: `${textSizes[textSize]}px`,
+          },
+          ".public-DraftEditor-content": {
+            overflow: "auto",
+            height: "200px",
           },
         }}
       >

--- a/frontend/src/components/common/RichText/RichTextField.tsx
+++ b/frontend/src/components/common/RichText/RichTextField.tsx
@@ -18,6 +18,7 @@ import {
   Image,
   Divider,
   Box,
+  Container,
   IconButton,
 } from "@chakra-ui/react";
 import "draft-js/dist/Draft.css";
@@ -400,25 +401,25 @@ const RichTextField: FunctionComponent<RichTextFieldProps> = (
           ))}
         </ButtonGroup>
       </HStack>
-      <Box
-        w="full"
+      <Container
         borderWidth={editorBorderWidth}
         borderRadius="sm"
         borderColor={editorBorderColor}
         overflowY="auto"
         p="12px"
+        m="12px"
+        minH="200px"
+        maxH="200px"
+        maxW="container.md"
+        sx={{
+          ...fontSizeObject,
+          ".public-DraftEditorPlaceholder-root": {
+            display: showPlaceHolder,
+            fontSize: `${textSizes[textSize]}px`,
+          },
+        }}
       >
-        <Box
-          h="200px"
-          fontSize="16px"
-          sx={{
-            ...fontSizeObject,
-            ".public-DraftEditorPlaceholder-root": {
-              display: showPlaceHolder,
-              fontSize: `${textSizes[textSize]}px`,
-            },
-          }}
-        >
+        <Box>
           <Editor
             placeholder={defaultText}
             editorState={editorState}
@@ -427,7 +428,7 @@ const RichTextField: FunctionComponent<RichTextFieldProps> = (
             keyBindingFn={keyBindings}
           />
         </Box>
-      </Box>
+      </Container>
     </VStack>
   );
 };


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #279 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added missing properties for `draftEditor-content` to avoid cutting cursor view
* Use container for non-growing container width, other wise very long lines could make editor infinitely long, stretching all other components

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `http://localhost:3000/admin/posting/create/basic-info`
2. Enter some characters, spam `enter`, cursor should always be visible and within view
3. Enter some really long line, line should wrap instead of growing editor width

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
