### PR TITLE
User able to create multi-day shifts bug

### DIFF
--- a/backend/graphql/types/postingType.ts
+++ b/backend/graphql/types/postingType.ts
@@ -47,7 +47,7 @@ const postingType = gql`
     branch: BranchResponseDTO!
     shifts: [ShiftResponseDTO!]!
     skills: [SkillResponseDTO!]!
-    employees: [EmployeeResponseDTO!]!
+    employees: [EmployeeUserResponseDTO!]!
     title: String!
     type: PostingType!
     status: PostingStatus!

--- a/backend/graphql/types/postingType.ts
+++ b/backend/graphql/types/postingType.ts
@@ -58,12 +58,6 @@ const postingType = gql`
     numVolunteers: Int!
   }
 
-  type EmployeeResponseDTO {
-    id: ID!
-    branchId: ID!
-    title: String!
-  }
-
   extend type Query {
     posting(id: ID!): PostingResponseDTO!
     postings(

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -94,16 +94,16 @@ const convertToSkillResponseDTO = (skills: Skill[]): SkillResponseDTO[] => {
   });
 };
 
-const convertToEmployeeUserResponseDTO = async (
-  employees: Employee[],
-  userService: IUserService,
-): Promise<EmployeeUserResponseDTO[]> => {
-  return Promise.all(
-    employees.map(async (employee) => {
-      return userService.getEmployeeUserById(String(employee.id));
-    }),
-  );
-};
+// const convertToEmployeeUserResponseDTO = async (
+//   employees: Employee[],
+//   userService: IUserService,
+// ): Promise<EmployeeUserResponseDTO[]> => {
+//   return Promise.all(
+//     employees.map(async (employee) => {
+//       return userService.getEmployeeUserById(String(employee.id));
+//     }),
+//   );
+// };
 
 class PostingService implements IPostingService {
   shiftService: IShiftService;
@@ -124,6 +124,16 @@ class PostingService implements IPostingService {
       Logger.error(`Failed to get user. Reason = ${getErrorMessage(error)}`);
       throw error;
     }
+  }
+
+  async convertToEmployeeUserResponseDTO(
+    employees: Employee[],
+  ): Promise<EmployeeUserResponseDTO[]> {
+    return Promise.all(
+      employees.map(async (employee) => {
+        return this.userService.getEmployeeUserById(String(employee.id));
+      }),
+    );
   }
 
   async getPosting(postingId: string): Promise<PostingResponseDTO> {
@@ -150,9 +160,8 @@ class PostingService implements IPostingService {
       throw error;
     }
 
-    const employeeUsers = await convertToEmployeeUserResponseDTO(
+    const employeeUsers = await this.convertToEmployeeUserResponseDTO(
       posting.employees,
-      this.userService,
     );
 
     return {
@@ -206,10 +215,10 @@ class PostingService implements IPostingService {
         );
         return await Promise.all(
           postings.map(async (posting: PostingWithRelations) => {
-            const employeeUsers: EmployeeUserResponseDTO[] = await convertToEmployeeUserResponseDTO(
+            const employeeUsers: EmployeeUserResponseDTO[] = await this.convertToEmployeeUserResponseDTO(
               posting.employees,
-              this.userService,
             );
+
             return {
               id: String(posting.id),
               branch: convertToBranchResponseDTO(posting.branch),
@@ -292,10 +301,10 @@ class PostingService implements IPostingService {
       throw error;
     }
 
-    const employeeUsers: EmployeeUserResponseDTO[] = await convertToEmployeeUserResponseDTO(
+    const employeeUsers: EmployeeUserResponseDTO[] = await this.convertToEmployeeUserResponseDTO(
       newPosting.employees,
-      this.userService,
     );
+
     return {
       id: String(newPosting.id),
       branch: convertToBranchResponseDTO(newPosting.branch),
@@ -361,9 +370,8 @@ class PostingService implements IPostingService {
       throw error;
     }
 
-    const employeesArr: EmployeeUserResponseDTO[] = await convertToEmployeeUserResponseDTO(
+    const employeeUsers: EmployeeUserResponseDTO[] = await this.convertToEmployeeUserResponseDTO(
       updateResult.employees,
-      this.userService,
     );
 
     return {
@@ -371,7 +379,7 @@ class PostingService implements IPostingService {
       branch: convertToBranchResponseDTO(updateResult.branch),
       shifts: convertToShiftResponseDTO(updateResult.shifts),
       skills: convertToSkillResponseDTO(updateResult.skills),
-      employees: employeesArr,
+      employees: employeeUsers,
       title: updateResult.title,
       type: updateResult.type,
       status: updateResult.status,

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -94,18 +94,16 @@ const convertToSkillResponseDTO = (skills: Skill[]): SkillResponseDTO[] => {
   });
 };
 
-
-
 const convertToEmployeeUserResponseDTO = async (
-  employees: Employee[], userService: IUserService,
+  employees: Employee[],
+  userService: IUserService,
 ): Promise<EmployeeUserResponseDTO[]> => {
   return Promise.all(
     employees.map(async (employee) => {
       return userService.getEmployeeUserById(String(employee.id));
     }),
-  )};
-
-
+  );
+};
 
 class PostingService implements IPostingService {
   shiftService: IShiftService;
@@ -117,8 +115,6 @@ class PostingService implements IPostingService {
     this.userService = userService;
     this.shiftService = shiftService;
   }
-
-
 
   async getUserBranchesByUserId(userId: string): Promise<number[]> {
     try {
@@ -154,7 +150,10 @@ class PostingService implements IPostingService {
       throw error;
     }
 
-    const employeeUsers = await convertToEmployeeUserResponseDTO(posting.employees, this.userService)
+    const employeeUsers = await convertToEmployeeUserResponseDTO(
+      posting.employees,
+      this.userService,
+    );
 
     return {
       id: String(posting.id),
@@ -205,27 +204,29 @@ class PostingService implements IPostingService {
             },
           },
         );
-        return await Promise.all(postings.map(async (posting: PostingWithRelations) => {
-
-          const employeeUsers: EmployeeUserResponseDTO[] = await convertToEmployeeUserResponseDTO(
-            posting.employees,this.userService
-          );
-          return {
-            id: String(posting.id),
-            branch: convertToBranchResponseDTO(posting.branch),
-            shifts: convertToShiftResponseDTO(posting.shifts),
-            skills: convertToSkillResponseDTO(posting.skills),
-            employees: employeeUsers,
-            title: posting.title,
-            type: posting.type,
-            status: posting.status,
-            description: posting.description,
-            startDate: posting.startDate,
-            endDate: posting.endDate,
-            autoClosingDate: posting.autoClosingDate,
-            numVolunteers: posting.numVolunteers,
-          };
-        }));
+        return await Promise.all(
+          postings.map(async (posting: PostingWithRelations) => {
+            const employeeUsers: EmployeeUserResponseDTO[] = await convertToEmployeeUserResponseDTO(
+              posting.employees,
+              this.userService,
+            );
+            return {
+              id: String(posting.id),
+              branch: convertToBranchResponseDTO(posting.branch),
+              shifts: convertToShiftResponseDTO(posting.shifts),
+              skills: convertToSkillResponseDTO(posting.skills),
+              employees: employeeUsers,
+              title: posting.title,
+              type: posting.type,
+              status: posting.status,
+              description: posting.description,
+              startDate: posting.startDate,
+              endDate: posting.endDate,
+              autoClosingDate: posting.autoClosingDate,
+              numVolunteers: posting.numVolunteers,
+            };
+          }),
+        );
       } catch (error: unknown) {
         Logger.error(
           `Failed to get postings. Reason = ${getErrorMessage(error)}`,
@@ -292,7 +293,8 @@ class PostingService implements IPostingService {
     }
 
     const employeeUsers: EmployeeUserResponseDTO[] = await convertToEmployeeUserResponseDTO(
-      newPosting.employees, this.userService
+      newPosting.employees,
+      this.userService,
     );
     return {
       id: String(newPosting.id),
@@ -360,7 +362,8 @@ class PostingService implements IPostingService {
     }
 
     const employeesArr: EmployeeUserResponseDTO[] = await convertToEmployeeUserResponseDTO(
-      updateResult.employees, this.userService
+      updateResult.employees,
+      this.userService,
     );
 
     return {

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -94,17 +94,6 @@ const convertToSkillResponseDTO = (skills: Skill[]): SkillResponseDTO[] => {
   });
 };
 
-// const convertToEmployeeUserResponseDTO = async (
-//   employees: Employee[],
-//   userService: IUserService,
-// ): Promise<EmployeeUserResponseDTO[]> => {
-//   return Promise.all(
-//     employees.map(async (employee) => {
-//       return userService.getEmployeeUserById(String(employee.id));
-//     }),
-//   );
-// };
-
 class PostingService implements IPostingService {
   shiftService: IShiftService;
 

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -41,12 +41,6 @@ export type PostingResponseDTO = Omit<
   employees: EmployeeUserResponseDTO[];
 };
 
-export type EmployeeResponseDTO = {
-  id: string;
-  branchId: string;
-  title: string;
-};
-
 export type VolunteerDTO = {
   id: string;
   hireDate: Date;

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -38,7 +38,7 @@ export type PostingResponseDTO = Omit<
   branch: BranchResponseDTO;
   shifts: ShiftResponseDTO[];
   skills: SkillResponseDTO[];
-  employees: EmployeeResponseDTO[];
+  employees: EmployeeUserResponseDTO[];
 };
 
 export type EmployeeResponseDTO = {

--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -118,8 +118,8 @@ const WeekViewShiftCalendar = ({
         timeZone="UTC"
         initialDate={initialDate}
         selectConstraint={{
-          startTime: '0:00', 
-          endTime: '24:00'
+          startTime: "0:00",
+          endTime: "24:00",
         }}
         eventConstraint="businessHours"
       />

--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -117,6 +117,11 @@ const WeekViewShiftCalendar = ({
         slotLabelInterval="01:00"
         timeZone="UTC"
         initialDate={initialDate}
+        selectConstraint={{
+          startTime: '0:00', 
+          endTime: '24:00'
+        }}
+        eventConstraint="businessHours"
       />
     </Box>
   );

--- a/frontend/src/components/common/PostingDetails.tsx
+++ b/frontend/src/components/common/PostingDetails.tsx
@@ -62,7 +62,7 @@ const PostingDetails = ({
         </Text>
         <Text textStyle="body-regular">Point(s) of contact:</Text>
         <HStack pb={4}>
-        {postingDetails.employees.map((employee) => (
+          {postingDetails.employees.map((employee) => (
             <PocCard
               name={`${employee.firstName} ${employee.lastName}`}
               title={employee.title}

--- a/frontend/src/components/common/PostingDetails.tsx
+++ b/frontend/src/components/common/PostingDetails.tsx
@@ -62,20 +62,15 @@ const PostingDetails = ({
         </Text>
         <Text textStyle="body-regular">Point(s) of contact:</Text>
         <HStack pb={4}>
-          <PocCard
-            name="John Doe"
-            title="hard code"
-            email="hard code"
-            phoneNumber="hard code"
-            key={1}
-          />
-          <PocCard
-            name="John Doe"
-            title="hard code"
-            email="hard code"
-            phoneNumber="hard code"
-            key={1}
-          />
+        {postingDetails.employees.map((employee) => (
+            <PocCard
+              name={`${employee.firstName} ${employee.lastName}`}
+              title={employee.title}
+              email={employee.email}
+              phoneNumber={employee.phoneNumber ?? "Not available"}
+              key={employee.id}
+            />
+          ))}
         </HStack>
         <Divider />
         <HStack justifyContent="space-between" pt={4} w="full">

--- a/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
+++ b/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
@@ -23,6 +23,11 @@ const POSTING = gql`
       }
       employees {
         id
+        firstName
+        lastName
+        email
+        title
+        phoneNumber
       }
       autoClosingDate
     }

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
@@ -31,6 +31,11 @@ const POSTING = gql`
       }
       employees {
         id
+        firstName
+        lastName
+        email
+        title
+        phoneNumber
       }
       autoClosingDate
     }

--- a/frontend/src/types/api/EmployeeTypes.ts
+++ b/frontend/src/types/api/EmployeeTypes.ts
@@ -1,9 +1,3 @@
-export type EmployeeResponseDTO = {
-  id: string;
-  branchId: string;
-  title: string;
-};
-
 export type EmployeeUserDTO = {
   id: string;
   firstName: string;

--- a/frontend/src/types/api/PostingTypes.ts
+++ b/frontend/src/types/api/PostingTypes.ts
@@ -1,7 +1,7 @@
 import { BranchResponseDTO } from "./BranchTypes";
 import { SkillResponseDTO } from "./SkillTypes";
 import { ShiftResponseDTO, RecurrenceInterval, TimeBlock } from "./ShiftTypes";
-import { EmployeeResponseDTO } from "./EmployeeTypes";
+import { EmployeeUserResponseDTO } from "./EmployeeTypes";
 
 export type PostingType = "INDIVIDUAL" | "GROUP";
 
@@ -36,5 +36,5 @@ export type PostingResponseDTO = Omit<
   branch: BranchResponseDTO;
   shifts: ShiftResponseDTO[];
   skills: SkillResponseDTO[];
-  employees: EmployeeResponseDTO[];
+  employees: EmployeeUserResponseDTO[];
 };


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #284 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added a selectConstraint prop that disables users from being able to drag multi day events 
* see documentation: https://fullcalendar.io/docs/selectConstraint


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. http://localhost:3000/admin/posting/create/basic-info, enter any necessary info and click next to "Scheduling Time Slots"
2. In the calendar, try dragging your mouse over an event that spans over multiple days, this should be disabled

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* whether the changes work as intended


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
