### PR TITLE
disable admin from creating multi-day shifts

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -117,6 +117,10 @@ const WeekViewShiftCalendar = ({
         slotLabelInterval="01:00"
         timeZone="UTC"
         initialDate={initialDate}
+        selectConstraint={{
+          startTime: "0:00",
+          endTime: "24:00",
+        }}
       />
     </Box>
   );

--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -47,7 +47,6 @@ const WeekViewShiftCalendar = ({
   startDate,
   endDate,
 }: ShiftCalendarProps): React.ReactElement => {
-
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const openModal = (): void => {

--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -7,7 +7,7 @@ import FullCalendar, {
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import React, { useState } from "react";
-import moment from 'moment';
+import moment from "moment";
 import {
   Box,
   Button,
@@ -32,8 +32,8 @@ type ShiftCalendarProps = {
   changeEvent: (event: Event, oldEvent: Event, currEvents: Event[]) => void;
   deleteEvent: (currEvents: Event[]) => void;
   initialDate?: string;
-  startDate: string, 
-  endDate: string,
+  startDate: string;
+  endDate: string;
 };
 
 const WeekViewShiftCalendar = ({
@@ -44,10 +44,10 @@ const WeekViewShiftCalendar = ({
   changeEvent,
   deleteEvent,
   initialDate,
-  startDate, 
+  startDate,
   endDate,
 }: ShiftCalendarProps): React.ReactElement => {
-  console.log(startDate, endDate)
+
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const openModal = (): void => {
@@ -123,8 +123,11 @@ const WeekViewShiftCalendar = ({
         slotLabelInterval="01:00"
         timeZone="UTC"
         initialDate={initialDate}
-        selectConstraint={{ startTime: '0:00', endTime: '24:00'}}
-        validRange={{start: startDate, end: moment(endDate).add(1, 'day').format('YYYY-MM-DD')}}
+        selectConstraint={{ startTime: "0:00", endTime: "24:00" }}
+        validRange={{
+          start: startDate,
+          end: moment(endDate).add(1, "day").format("YYYY-MM-DD"),
+        }}
       />
     </Box>
   );

--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -7,6 +7,7 @@ import FullCalendar, {
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import React, { useState } from "react";
+import moment from 'moment';
 import {
   Box,
   Button,
@@ -31,6 +32,8 @@ type ShiftCalendarProps = {
   changeEvent: (event: Event, oldEvent: Event, currEvents: Event[]) => void;
   deleteEvent: (currEvents: Event[]) => void;
   initialDate?: string;
+  startDate: string, 
+  endDate: string,
 };
 
 const WeekViewShiftCalendar = ({
@@ -41,7 +44,10 @@ const WeekViewShiftCalendar = ({
   changeEvent,
   deleteEvent,
   initialDate,
+  startDate, 
+  endDate,
 }: ShiftCalendarProps): React.ReactElement => {
+  console.log(startDate, endDate)
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const openModal = (): void => {
@@ -111,16 +117,14 @@ const WeekViewShiftCalendar = ({
         plugins={[timeGridPlugin, interactionPlugin]}
         select={(selectInfo: DateSelectArg) => addEvent(selectInfo)}
         selectMirror
-        selectable
+        selectable={Boolean(startDate && endDate)}
         scrollTime="09:00:00"
         slotDuration="00:15:00"
         slotLabelInterval="01:00"
         timeZone="UTC"
         initialDate={initialDate}
-        selectConstraint={{
-          startTime: "0:00",
-          endTime: "24:00",
-        }}
+        selectConstraint={{ startTime: '0:00', endTime: '24:00'}}
+        validRange={{start: startDate, end: moment(endDate).add(1, 'day').format('YYYY-MM-DD')}}
       />
     </Box>
   );

--- a/frontend/src/components/admin/posting/CreatePostingShifts.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingShifts.tsx
@@ -97,6 +97,7 @@ const CreatePostingShifts: React.FC<CreatePostingShiftsProps> = ({
   }, [startDate, setEvents]);
 
   const addEvent = (newEvent: DateSelectArg) => {
+    console.log(newEvent.start)
     setEvents([
       ...events,
       {
@@ -341,6 +342,8 @@ const CreatePostingShifts: React.FC<CreatePostingShiftsProps> = ({
           addEvent={addEvent}
           changeEvent={changeEvent}
           deleteEvent={deleteEvent}
+          startDate={startDate}
+          endDate={endDate}
           /* eslint-disable-next-line react/jsx-props-no-spreading */
           {...initialDateProps}
         />

--- a/frontend/src/components/admin/posting/CreatePostingShifts.tsx
+++ b/frontend/src/components/admin/posting/CreatePostingShifts.tsx
@@ -97,7 +97,6 @@ const CreatePostingShifts: React.FC<CreatePostingShiftsProps> = ({
   }, [startDate, setEvents]);
 
   const addEvent = (newEvent: DateSelectArg) => {
-    console.log(newEvent.start)
     setEvents([
       ...events,
       {


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #284 and #285


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description

new side effects: user must now select a start and end date before select a shift time on the calendar, times on the calendar out of the start-end date range is grey (see below)
![Screen Shot 2022-05-07 at 11 54 40 PM](https://user-images.githubusercontent.com/82241706/167281203-404f5720-6889-4145-8c1d-76885d7eee58.png)

* added a selectConstraint prop that disables users from being able to drag multi day events
* added a validRange prop based on the selected start and end dates
* see documentation: https://fullcalendar.io/docs/selectConstraint, https://fullcalendar.io/docs/validRange


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.http://localhost:3000/admin/posting/create/basic-info, enter any necessary info and click next to "Scheduling Time Slots"
2. Select a start and end date in the same week (such as Tues-thurs), try adding an event on Friday (this should be disabled) 
3. In the calendar, try dragging your mouse over an event that spans over multiple days (this should be disabled)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* whether the changes work as intended


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
