### PR TITLE
filter by day click

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -14,11 +14,13 @@ import MonthlyViewShiftCalendar from "./MonthlyViewReadOnlyShiftCalendar";
 type MonthViewShiftCalendarProps = {
   events: MonthEvent[];
   shifts: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
+  onDayClick: (calendarDay: Date) => void;
 };
 
 const MonthViewShiftCalendar = ({
   events,
   shifts,
+  onDayClick,
 }: MonthViewShiftCalendarProps): React.ReactElement => {
   const sortEvents = (unsortedEvents: MonthEvent[]): MonthEvent[] => {
     return unsortedEvents.sort((a, b) => {
@@ -112,6 +114,7 @@ const MonthViewShiftCalendar = ({
         events={getEventsInMonth()}
         shifts={shifts}
         initialDate={selectedMonth}
+        onDayClick={onDayClick}
       />
     </Box>
   ) : (

--- a/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
@@ -5,12 +5,14 @@ import FullCalendar, {
   EventInput,
 } from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
 import { Box } from "@chakra-ui/react";
 
 import { Event } from "../../../types/CalendarTypes";
 import colors from "../../../theme/colors";
 import "./Calendar.css";
 import { AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO } from "../../../types/api/ShiftTypes";
+import { getISOStringDateTime } from "../../../utils/DateTimeUtils";
 
 // Events can be passed in any order (does not have to be sorted).
 // AdminShiftCalendar assumes that all events are in the same month.
@@ -18,12 +20,14 @@ type AdminShiftCalendarProps = {
   events: Event[];
   shifts: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
   initialDate: Date;
+  onDayClick: (calendarDay: Date) => void;
 };
 
 const MonthlyViewShiftCalendar = ({
   events,
   shifts,
   initialDate,
+  onDayClick,
 }: AdminShiftCalendarProps): React.ReactElement => {
   const calendarRef = React.useRef<FullCalendar>(null);
 
@@ -78,6 +82,9 @@ const MonthlyViewShiftCalendar = ({
         displayEventEnd
         dayCellClassNames={(day: DayCellContentArg) => applyCellClasses(day)}
         editable
+        dateClick={({ date }) =>
+          onDayClick(new Date(getISOStringDateTime(date)))
+        }
         // eventClick --> Show side panel, TODO in ticket #176
         eventColor={colors.violet}
         eventContent={displayCustomEvent}
@@ -91,7 +98,7 @@ const MonthlyViewShiftCalendar = ({
         headerToolbar={false}
         initialDate={initialDate}
         initialView="dayGridMonth"
-        plugins={[dayGridPlugin]}
+        plugins={[dayGridPlugin, interactionPlugin]}
         selectable
         ref={calendarRef}
         timeZone="UTC"

--- a/frontend/src/components/admin/schedule/AdminScheduleTable.tsx
+++ b/frontend/src/components/admin/schedule/AdminScheduleTable.tsx
@@ -14,10 +14,7 @@ import AdminScheduleTableDate from "./AdminScheduleTableDate";
 import AdminScheduleTableRow from "./AdminScheduleTableRow";
 import { getWeekDiff } from "../../../utils/DateTimeUtils";
 import { AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO } from "../../../types/api/ShiftTypes";
-import {
-  AdminSchedulingSignupsAndVolunteerResponseDTO,
-  SignupsAndVolunteerGraphQLResponseDTO,
-} from "../../../types/api/SignupTypes";
+import { AdminSchedulingSignupsAndVolunteerResponseDTO } from "../../../types/api/SignupTypes";
 
 export type AdminScheduleSignup = {
   startTime: Date;

--- a/frontend/src/components/admin/schedule/ScheduleSidePanel.tsx
+++ b/frontend/src/components/admin/schedule/ScheduleSidePanel.tsx
@@ -37,8 +37,7 @@ const ScheduleSidePanel: React.FC<ScheduleSidePanelProps> = ({
   const [isEditing, setIsEditing] = useBoolean(false);
 
   useEffect(() => {
-    if (!selectedShift) return;
-    const updatedShift = shifts.find((shift) => shift.id === selectedShift.id);
+    const updatedShift = shifts.find((shift) => shift.id === selectedShift?.id);
     setSelectedShift(updatedShift ?? shifts[0]);
   }, [shifts, selectedShift]);
 

--- a/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
@@ -285,7 +285,7 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
             {tableDataLoading || postingLoading ? (
               <Loading />
             ) : (
-              ShiftScheduleCalendar({ shifts })
+              ShiftScheduleCalendar({ shifts, onDayClick: handleDayClick })
             )}
           </Box>
           <Box w="400px" overflow="hidden">


### PR DESCRIPTION
<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to /admin/schedule/posting/1
2. Click on a day
3. Check that the shifts filter to that day
There is a bug for some shift times (seems to be the ones closer to 12 like 1am-3am so it may be due to timezone issues) where the day the shift is being displayed on the calendar is +/- 1 day of the actual shift date :') But it should work sometimes so...yah

![](https://media.giphy.com/media/nrXif9YExO9EI/giphy.gif)
## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
