### PR TITLE
Fix side panel big, schedule calendar display bug, volunteer postings bug

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
@@ -4,6 +4,7 @@ import FullCalendar, {
   EventContentArg,
   EventInput,
 } from "@fullcalendar/react";
+
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { Box } from "@chakra-ui/react";
@@ -12,7 +13,6 @@ import { Event } from "../../../types/CalendarTypes";
 import colors from "../../../theme/colors";
 import "./Calendar.css";
 import { AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO } from "../../../types/api/ShiftTypes";
-import { getISOStringDateTime } from "../../../utils/DateTimeUtils";
 
 // Events can be passed in any order (does not have to be sorted).
 // AdminShiftCalendar assumes that all events are in the same month.
@@ -82,9 +82,7 @@ const MonthlyViewShiftCalendar = ({
         displayEventEnd
         dayCellClassNames={(day: DayCellContentArg) => applyCellClasses(day)}
         editable
-        dateClick={({ date }) =>
-          onDayClick(new Date(getISOStringDateTime(date)))
-        }
+        dateClick={({ date }) => onDayClick(date)}
         // eventClick --> Show side panel, TODO in ticket #176
         eventColor={colors.violet}
         eventContent={displayCustomEvent}

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -5,10 +5,7 @@ import { gql, useMutation } from "@apollo/client";
 import { Text } from "@chakra-ui/react";
 
 import authAPIClient from "../../APIClients/AuthAPIClient";
-import {
-  RESET_PASSWORD_PAGE,
-  HOME_PAGE,
-} from "../../constants/Routes";
+import { RESET_PASSWORD_PAGE, HOME_PAGE } from "../../constants/Routes";
 
 import AuthContext from "../../contexts/AuthContext";
 import { AuthenticatedUser } from "../../types/AuthTypes";
@@ -102,4 +99,3 @@ const Login = (): React.ReactElement => {
 };
 
 export default Login;
-

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -15,7 +15,6 @@ const Default = (): React.ReactElement => {
     return <Redirect to={Routes.VOLUNTEER_POSTINGS_PAGE} />;
   }
 
-
   return (
     <div style={{ textAlign: "center", paddingTop: "20px" }}>
       <Text textStyle="display-large">Welcome to Sistering</Text>

--- a/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
@@ -20,6 +20,7 @@ import MonthViewShiftCalendar from "../../../admin/ShiftCalendar/MonthViewShiftC
 import AdminScheduleTable from "../../../admin/schedule/AdminScheduleTable";
 import ScheduleSidePanel from "../../../admin/schedule/ScheduleSidePanel";
 import Loading from "../../../common/Loading";
+import { getUTCDateForDateTimeString } from "../../../../utils/DateTimeUtils";
 
 type AdminScheduleTableDataQueryResponse = {
   shiftsWithSignupsAndVolunteersByPosting: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
@@ -103,8 +104,8 @@ const ShiftScheduleCalendar = ({
       events={shifts.map((shift) => {
         return {
           id: shift.id,
-          start: new Date(shift.startTime),
-          end: new Date(shift.endTime),
+          start: getUTCDateForDateTimeString(shift.startTime.toString()),
+          end: getUTCDateForDateTimeString(shift.endTime.toString()),
           groupId: "", // TODO: Add groupId for saved/unsaved
         };
       })}
@@ -255,7 +256,7 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
   const handleDayClick = (calendarDate: Date) => {
     setSidePanelShifts(
       shifts.filter((shift) =>
-        moment(shift.startTime).isSame(moment(calendarDate), "day"),
+        moment.utc(shift.startTime).isSame(moment.utc(calendarDate), "day"),
       ),
     );
   };

--- a/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
@@ -1,5 +1,5 @@
 import { Flex, Box, Text, Button, Spacer } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import cloneDeep from "lodash.clonedeep";
@@ -133,6 +133,15 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
   const [sidePanelShifts, setSidePanelShifts] = useState<
     AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[]
   >([]);
+  const [selectedDay, setSelectedDay] = useState<Date>();
+
+  useEffect(() => {
+    setSidePanelShifts(
+      shifts.filter((shift) =>
+        moment.utc(shift.startTime).isSame(moment.utc(selectedDay), "day"),
+      ),
+    );
+  }, [shifts, selectedDay]);
 
   const { error: tableDataQueryError, loading: tableDataLoading } = useQuery<
     AdminScheduleTableDataQueryResponse,
@@ -146,6 +155,7 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
 
       if (shiftsData.length) {
         const firstDay = shiftsData[0]?.startTime;
+        setSelectedDay(firstDay);
         setSidePanelShifts(
           shiftsData.filter((shift) =>
             moment(shift.startTime).isSame(moment(firstDay), "day"),
@@ -226,6 +236,8 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
     }
   };
 
+  const handleDayClick = (calendarDate: Date) => setSelectedDay(calendarDate);
+
   const handleSidePanelSaveClick = async () => {
     if (!currentlyEditingShift) return;
     await submitSignups({
@@ -251,14 +263,6 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
     setShifts(shiftsCopy);
 
     setcurrentlyEditingShift(undefined);
-  };
-
-  const handleDayClick = (calendarDate: Date) => {
-    setSidePanelShifts(
-      shifts.filter((shift) =>
-        moment.utc(shift.startTime).isSame(moment.utc(calendarDate), "day"),
-      ),
-    );
   };
 
   return (

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -12,7 +12,10 @@ import {
   PostingResponseDTO,
   PostingStatus,
 } from "../../../../types/api/PostingTypes";
-import { dateInRange } from "../../../../utils/DateTimeUtils";
+import {
+  dateInRange,
+  getUTCDateForDateTimeString,
+} from "../../../../utils/DateTimeUtils";
 import { FilterType } from "../../../../types/DateFilterTypes";
 import EmptyPostingCard from "../../../volunteer/EmptyPostingCard";
 import PostingCard from "../../../volunteer/PostingCard";
@@ -64,7 +67,9 @@ const VolunteerPostingsPage = (): React.ReactElement => {
 
   const { error } = useQuery(POSTINGS, {
     variables: {
-      closingDate: new Date().toISOString().split("T")[0],
+      closingDate: getUTCDateForDateTimeString(new Date().toString())
+        .toISOString()
+        .split("T")[0],
       statuses: ["PUBLISHED" as PostingStatus],
       userId: authenticatedUser?.id,
     },

--- a/frontend/src/utils/DateTimeUtils.ts
+++ b/frontend/src/utils/DateTimeUtils.ts
@@ -8,7 +8,7 @@ import { FilterType } from "../types/DateFilterTypes";
  * @returns corresponding time string string in format hh:mm:(a/p)m
  */
 export const formatTimeHourMinutes = (date: Date): string => {
-  return moment(date).utc().format("h:mm a");
+  return moment.utc(date).format("h:mm a");
 };
 
 /**


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #324 #329 #336 #332 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Each commit corresponds to solving a different bug:
1. The calendar dates in the Admin Scheduling flow are now being converted to UTC. This means that when clicking on a day, the user will be able to choose 

2. For the volunteer postings flow, for the autoClosingDate filter when we fetch all postings, we were previously calling `new Date().getISOString()`. This will convert the current date, in whatever timezone you're in, to UTC. However, depending what timezone you're in and what time it is, if you are searching for posting on May 15, for example, we may be querying for postings with an autoclosing date greater or equal to May 16 (because getISOString() converts the date to UTC). Instead, we want to get the current day that is local to you and use that for the autoclosing date filter.

3. Side panel shifts should now update after you click "Save" 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
Bug #336 #324 
1. Go to /admin/schedule/posting/{id}
2. Click on a day and check that the correct day with the correct shifts show in the side panel
3. select days with and without shifts
4. Try creating a new posting with shift times near 12 am
5. repeat steps 2-3

Bug #332 
1. Create a posting for shifts within a week of today.
2. Login as a volunteer and go to `/volunteer/postings`
3. The filter in the top right should be set to `This Week`
4. Check that postings within a week of today are showing

Bug #329 
1. Go to /admin/schedule/posting/{id} - choose a posting that has signups
2. Click on a day that has signups
3. Check or uncheck some signups
4. Click Save
5. The changes to your checkboxes should persist after you click save

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
I would recommend reviewing by commit. 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
