### PR TITLE
Publish admin schedule

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
@@ -42,7 +42,7 @@ const MonthlyViewShiftCalendar = ({
     const shift = shifts.find((currShift) => currShift.id === content.event.id);
     if (shift) {
       const isConfirmed = shift.signups.some(
-        (signup) => signup.status === "CONFIRMED",
+        ({ status }) => status === "CONFIRMED" || status === "PUBLISHED",
       );
       return (
         <>

--- a/frontend/src/components/admin/schedule/AdminScheduleTable.tsx
+++ b/frontend/src/components/admin/schedule/AdminScheduleTable.tsx
@@ -137,7 +137,8 @@ const AdminScheduleTable = ({
             )
             .map((shift) => {
               const signupsToDisplay = shift.signups.filter(
-                (signup) => signup.status === "CONFIRMED",
+                ({ status }) =>
+                  status === "CONFIRMED" || status === "PUBLISHED",
               );
               return (
                 <Fragment

--- a/frontend/src/types/api/SignupTypes.ts
+++ b/frontend/src/types/api/SignupTypes.ts
@@ -61,3 +61,5 @@ export type AdminSchedulingSignupsAndVolunteerResponseDTO = Omit<
 > & {
   volunteer: Pick<VolunteerUserResponseDTO, "firstName" | "lastName" | "id">;
 };
+
+export type UpsertSignupDTO = Omit<SignupDTO, "id">;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #362 

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Change the signup status to `PUBLISHED` when user clicks Publish 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Use an existing posting with signups
2. Go to `/admin/schedule/posting/{id}`
3. Click on a day with signups, checkmark some signups, click save.
4. Repeat 4 for a couple other days.
5. Click Review
6. Check that the signups in the table match the ones you checkmarked.
7. Click Publish
8. Login as a volunteer whose signup was published.
9. Go to `volunteer/shifts`, check that the correct shifts are under `Upcoming Shifts` (you may need to change the filter)


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
