### PR TITLE
Fix initial month state for MonthViewShiftCalendar

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -29,14 +29,16 @@ const MonthViewShiftCalendar = ({
   };
 
   // Current month to display, indicated by the first day of the month.
-  const [selectedMonth, setSelectedMonth] = React.useState<Date>(new Date());
+  const [selectedMonth, setSelectedMonth] = React.useState<Date>(new Date(0));
   const [sortedEvents, setSortedEvents] = React.useState<MonthEvent[]>([]);
 
   useEffect(() => {
     const sortedEventsList = sortEvents(events);
     setSortedEvents(sortedEventsList);
-    setSelectedMonth(getFirstDayOfMonth(sortedEventsList[0].start));
-  }, [events]);
+    if (moment(selectedMonth).diff(moment(new Date(0)), "days") === 0) {
+      setSelectedMonth(getFirstDayOfMonth(sortedEventsList[0].start));
+    }
+  }, [events, selectedMonth]);
 
   const getEventsInMonth = (): MonthEvent[] => {
     const selectedMonthString = moment(selectedMonth).format("YYYY-MM");


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #359

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Set initial month in shift calendar such that it doesn't reset itself every time it re-renders. If the selected month is new Date(0) (the epoch time), we reset it to first date in shift otherwise we leave it alone


https://user-images.githubusercontent.com/44826218/170158822-d6556034-1b62-4926-9aeb-e6b2c29fdc10.mp4


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Add a shift to a posting such that it stretches' 2 months
2. Go http://localhost:3000/admin/schedule/posting/1
3. Go to last month and select a day

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness of fix


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
