### PR TITLE
Add eventClick to full calendar to open sidebar to shift

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -15,12 +15,16 @@ type MonthViewShiftCalendarProps = {
   events: MonthEvent[];
   shifts: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
   onDayClick: (calendarDay: Date) => void;
+  onShiftClick: (
+    shift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO,
+  ) => void;
 };
 
 const MonthViewShiftCalendar = ({
   events,
   shifts,
   onDayClick,
+  onShiftClick,
 }: MonthViewShiftCalendarProps): React.ReactElement => {
   const sortEvents = (unsortedEvents: MonthEvent[]): MonthEvent[] => {
     return unsortedEvents.sort((a, b) => {
@@ -115,6 +119,7 @@ const MonthViewShiftCalendar = ({
         shifts={shifts}
         initialDate={selectedMonth}
         onDayClick={onDayClick}
+        onShiftClick={onShiftClick}
       />
     </Box>
   ) : (

--- a/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import FullCalendar, {
   DayCellContentArg,
+  EventClickArg,
   EventContentArg,
   EventInput,
 } from "@fullcalendar/react";
@@ -21,6 +22,9 @@ type AdminShiftCalendarProps = {
   shifts: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
   initialDate: Date;
   onDayClick: (calendarDay: Date) => void;
+  onShiftClick: (
+    shift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO,
+  ) => void;
 };
 
 const MonthlyViewShiftCalendar = ({
@@ -28,6 +32,7 @@ const MonthlyViewShiftCalendar = ({
   shifts,
   initialDate,
   onDayClick,
+  onShiftClick,
 }: AdminShiftCalendarProps): React.ReactElement => {
   const calendarRef = React.useRef<FullCalendar>(null);
 
@@ -64,6 +69,14 @@ const MonthlyViewShiftCalendar = ({
     );
   };
 
+  const onEventClick = (click: EventClickArg) => {
+    const shift = shifts.find((currShift) => currShift.id === click.event.id);
+    if (shift) {
+      onDayClick(shift.startTime);
+      onShiftClick(shift);
+    }
+  };
+
   // applyCellClasses is used to compute the day cell background color.
   const applyCellClasses = (day: DayCellContentArg) => {
     // FullCalendar doesn't support retrieving events of a day, so we have to
@@ -83,7 +96,7 @@ const MonthlyViewShiftCalendar = ({
         dayCellClassNames={(day: DayCellContentArg) => applyCellClasses(day)}
         editable
         dateClick={({ date }) => onDayClick(date)}
-        // eventClick --> Show side panel, TODO in ticket #176
+        eventClick={onEventClick}
         eventColor={colors.violet}
         eventContent={displayCustomEvent}
         events={events as EventInput[]}

--- a/frontend/src/components/admin/schedule/ScheduleSidePanel.tsx
+++ b/frontend/src/components/admin/schedule/ScheduleSidePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { VStack, Box, Text, useBoolean } from "@chakra-ui/react";
 import { formatDateStringYear } from "../../../utils/DateTimeUtils";
 
@@ -17,6 +17,10 @@ type ScheduleSidePanelProps = {
   onSignupCheckboxClick: (id: string, isChecked: boolean) => void;
   onSaveSignupsClick: () => Promise<void>;
   submitSignupsLoading: boolean;
+  selectedShift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO;
+  setSelectedShift: React.Dispatch<
+    React.SetStateAction<AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO>
+  >;
 };
 
 const ScheduleSidePanel: React.FC<ScheduleSidePanelProps> = ({
@@ -27,19 +31,10 @@ const ScheduleSidePanel: React.FC<ScheduleSidePanelProps> = ({
   onSignupCheckboxClick,
   onSaveSignupsClick,
   submitSignupsLoading,
+  selectedShift,
+  setSelectedShift,
 }: ScheduleSidePanelProps): React.ReactElement => {
-  const [
-    selectedShift,
-    setSelectedShift,
-  ] = useState<AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO>(
-    shifts[0],
-  );
   const [isEditing, setIsEditing] = useBoolean(false);
-
-  useEffect(() => {
-    const updatedShift = shifts.find((shift) => shift.id === selectedShift?.id);
-    setSelectedShift(updatedShift ?? shifts[0]);
-  }, [shifts, selectedShift]);
 
   const handleEditSaveButtonClick = async () => {
     if (!isEditing) {
@@ -86,6 +81,7 @@ const ScheduleSidePanel: React.FC<ScheduleSidePanelProps> = ({
           <ShiftTimeHeader
             shifts={shifts}
             onShiftSelected={handleShiftTimeSelect}
+            selectedShift={selectedShift}
           />
           <AdminScheduleVolunteerTable
             signups={selectedShift ? selectedShift.signups : []}

--- a/frontend/src/components/admin/schedule/ShiftTimeHeader.tsx
+++ b/frontend/src/components/admin/schedule/ShiftTimeHeader.tsx
@@ -6,11 +6,13 @@ import { AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO } from "../.
 type ShiftTimeHeaderProps = {
   shifts: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
   onShiftSelected: (id: string) => void;
+  selectedShift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO;
 };
 
 const ShiftTimeHeader: React.FC<ShiftTimeHeaderProps> = ({
   shifts,
   onShiftSelected,
+  selectedShift,
 }: ShiftTimeHeaderProps): React.ReactElement => {
   return (
     <VStack
@@ -29,6 +31,7 @@ const ShiftTimeHeader: React.FC<ShiftTimeHeaderProps> = ({
         size="md"
         textStyle="caption"
         onChange={(e) => onShiftSelected(String(e.target.value))}
+        value={selectedShift?.id ?? shifts[0].id}
       >
         {shifts.map((shift, i) => (
           <option key={i} value={shift.id}>

--- a/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
@@ -96,9 +96,13 @@ const POSTING = gql`
 const ShiftScheduleCalendar = ({
   shifts,
   onDayClick,
+  onShiftClick,
 }: {
   shifts: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
   onDayClick: (calendarDay: Date) => void;
+  onShiftClick: (
+    shift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO,
+  ) => void;
 }) =>
   shifts.length > 0 && (
     <MonthViewShiftCalendar
@@ -112,6 +116,7 @@ const ShiftScheduleCalendar = ({
       })}
       shifts={shifts}
       onDayClick={onDayClick}
+      onShiftClick={onShiftClick}
     />
   );
 
@@ -120,6 +125,12 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
   const [shifts, setShifts] = useState<
     AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[]
   >([]);
+  const [
+    selectedShift,
+    setSelectedShift,
+  ] = useState<AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO>(
+    shifts[0],
+  );
   const [
     currentlyEditingShift,
     setcurrentlyEditingShift,
@@ -137,12 +148,20 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
   const [selectedDay, setSelectedDay] = useState<Date>();
 
   useEffect(() => {
-    setSidePanelShifts(
-      shifts.filter((shift) =>
-        moment.utc(shift.startTime).isSame(moment.utc(selectedDay), "day"),
-      ),
+    const shiftsOfDay = shifts.filter((shift) =>
+      moment.utc(shift.startTime).isSame(moment.utc(selectedDay), "day"),
     );
-  }, [shifts, selectedDay]);
+    setSidePanelShifts(shiftsOfDay);
+    // Set selected shift to first shift if current selected is not in same day
+    if (
+      selectedShift &&
+      !moment
+        .utc(selectedShift.startTime)
+        .isSame(moment.utc(selectedDay), "day")
+    ) {
+      setSelectedShift(shiftsOfDay[0]);
+    }
+  }, [shifts, selectedDay, selectedShift]);
 
   const { error: tableDataQueryError, loading: tableDataLoading } = useQuery<
     AdminScheduleTableDataQueryResponse,
@@ -239,6 +258,10 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
 
   const handleDayClick = (calendarDate: Date) => setSelectedDay(calendarDate);
 
+  const handleShiftClick = (
+    shift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO,
+  ) => setSelectedShift(shift);
+
   const handleSidePanelSaveClick = async () => {
     if (!currentlyEditingShift) return;
     await submitSignups({
@@ -324,7 +347,11 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
             {tableDataLoading || postingLoading ? (
               <Loading />
             ) : (
-              ShiftScheduleCalendar({ shifts, onDayClick: handleDayClick })
+              ShiftScheduleCalendar({
+                shifts,
+                onDayClick: handleDayClick,
+                onShiftClick: handleShiftClick,
+              })
             )}
           </Box>
           <Box w="400px" overflow="hidden">
@@ -336,6 +363,8 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
               onSignupCheckboxClick={handleSignupCheckboxClick}
               onSaveSignupsClick={handleSidePanelSaveClick}
               submitSignupsLoading={submitSignupsLoading}
+              selectedShift={selectedShift}
+              setSelectedShift={setSelectedShift}
             />
           </Box>
         </Flex>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #338 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Centralize selected shift state in top-level admin calendar component from calendar sidebar
* add eventClick to call drilled handler for setting selected shift
* change sidebar select shift header to strictly use `value` prop for consistency with selected shift


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. login as admin and go to http://localhost:3000/admin/schedule/posting/1
2. make small changes to shift times for a date with more than 1 shift (to differentiate between shifts on the same day)
3. click on each shift in the calendar individually and ensure sidebar header and table jumps to corresponding shift
4. ensure no regression occurred with calendar


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* correctness and cleanness
* no regression is introduced

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
