### PR TITLE
Don't reset scroll time for weekly calendar jumping bug

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -118,6 +118,7 @@ const WeekViewShiftCalendar = ({
         selectMirror
         selectable={Boolean(startDate && endDate)}
         scrollTime="09:00:00"
+        scrollTimeReset={false}
         slotDuration="00:15:00"
         slotLabelInterval="01:00"
         timeZone="UTC"


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #331 

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Set reset scroll time prop to false prevents calendar from rendering scroll time

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `/admin/posting/create/shifts` and fill out the form
2. Try creating shifts at 3am, 9pm, or times that requires scrolling outside the view of 9am
3. Calendar should no longer re-render and scroll to 9am after creating a new shift on the calendar


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* correctness


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
