### PR TITLE
Update selected shift state for sidebar on save

### DIFF
--- a/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/AdminSchedulePostingPage.tsx
@@ -287,6 +287,7 @@ const AdminSchedulePostingPage = (): React.ReactElement => {
     shiftsCopy[shiftIndex].signups = [...currentlyEditingShift.signups];
     setShifts(shiftsCopy);
 
+    setSelectedShift(currentlyEditingShift);
     setcurrentlyEditingShift(undefined);
   };
 


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #409


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* On save, we did not update the selected shift state in the sidebar which would be an outdated copy after saving the state
* This PR saves the selected shift state on save


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Sign up as admin and go to /admin/schedule/posting/1
2. Try to change status of a signup and save
3. The change shoudl reflect on the sidebar and the calendar


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
