### PR TITLE
Polish Admin Schedule table to show every day of week

### DIFF
--- a/frontend/src/components/admin/schedule/AdminScheduleTable.tsx
+++ b/frontend/src/components/admin/schedule/AdminScheduleTable.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Select,
   Spacer,
+  TableContainer,
 } from "@chakra-ui/react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import moment from "moment";
@@ -116,72 +117,67 @@ const AdminScheduleTable = ({
           Next week
         </Button>
       </Flex>
-      <Table variant="brand">
-        <colgroup>
-          <col style={{ width: "30%" }} />
-          <col style={{ width: "40%" }} />
-          <col style={{ width: "30%" }} />
-        </colgroup>
-        <Tbody>
-          {shifts
-            .filter(
+      <TableContainer>
+        <Table variant="brand">
+          <colgroup>
+            <col style={{ width: "30%" }} />
+            <col style={{ width: "40%" }} />
+            <col style={{ width: "30%" }} />
+          </colgroup>
+          {Array.from(Array(7).keys()).map((day) => {
+            const date = moment(currentWeek)
+              .startOf("week")
+              .add(day, "days")
+              .startOf("day")
+              .toDate();
+            const shiftsOfDate = shifts.filter(
               (shift) =>
                 moment(shift.startTime)
-                  .add(1, "day")
-                  .endOf("week")
-                  .diff(
-                    moment(currentWeek).add(1, "day").endOf("week"),
-                    "days",
-                    false,
-                  ) === 0,
-            )
-            .map((shift) => {
-              const signupsToDisplay = shift.signups.filter(
-                ({ status }) =>
-                  status === "CONFIRMED" || status === "PUBLISHED",
-              );
-              return (
-                <Fragment
-                  key={`${shift.id}-${new Date(
-                    shift.startTime,
-                  ).toDateString()}`}
-                >
-                  <AdminScheduleTableDate
-                    key={new Date(shift.startTime).toDateString()}
-                    date={new Date(shift.startTime)}
-                  />
-                  {signupsToDisplay.length > 0 ? (
-                    signupsToDisplay.map(
-                      (
-                        signup: AdminSchedulingSignupsAndVolunteerResponseDTO,
-                        i,
-                      ) => (
-                        <AdminScheduleTableRow
-                          key={`${signup.volunteer.id}-${i}`}
-                          volunteer={{
-                            name: `${signup.volunteer.firstName} ${signup.volunteer.lastName}`,
-                            userId: signup.volunteer.id,
-                          }}
-                          postingStart={signup.shiftStartTime}
-                          postingEnd={signup.shiftEndTime}
-                          numVolunteers={signup.numVolunteers}
-                          note={signup.note}
-                          shiftId={shift.id}
-                          removeSignup={removeSignup}
-                        />
-                      ),
-                    )
-                  ) : (
+                  .startOf("day")
+                  .diff(date, "days", false) === 0,
+            );
+            const signupsToDisplay: {
+              signup: AdminSchedulingSignupsAndVolunteerResponseDTO;
+              shiftId: string;
+            }[] = shiftsOfDate.flatMap((shift) => {
+              return shift.signups
+                .filter(
+                  ({ status }) =>
+                    status === "CONFIRMED" || status === "PUBLISHED",
+                )
+                .map((signup) => ({ signup, shiftId: shift.id }));
+            });
+
+            return (
+              <Tbody key={day}>
+                <AdminScheduleTableDate key={date.toDateString()} date={date} />
+                {signupsToDisplay.length > 0 ? (
+                  signupsToDisplay.map(({ signup, shiftId }, i) => (
                     <AdminScheduleTableRow
-                      shiftId={shift.id}
+                      key={`${signup.volunteer.id}-${i}`}
+                      volunteer={{
+                        name: `${signup.volunteer.firstName} ${signup.volunteer.lastName}`,
+                        userId: signup.volunteer.id,
+                      }}
+                      postingStart={signup.shiftStartTime}
+                      postingEnd={signup.shiftEndTime}
+                      numVolunteers={signup.numVolunteers}
+                      note={signup.note}
+                      shiftId={shiftId}
                       removeSignup={removeSignup}
                     />
-                  )}
-                </Fragment>
-              );
-            })}
-        </Tbody>
-      </Table>
+                  ))
+                ) : (
+                  <AdminScheduleTableRow
+                    shiftId="0"
+                    removeSignup={removeSignup}
+                  />
+                )}
+              </Tbody>
+            );
+          })}
+        </Table>
+      </TableContainer>
     </Box>
   );
 };


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #419

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Render table row on a per day basis by week instead of per confirmed shift on that week

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to /admin/schedule/posting/1 as admin
2. Click review button to go to schedule table
3. For each week, 7 days should be displayed, even if there are shifts in a particular day

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness and cleanness


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
