### PR TITLE
Remove User Modal

### DIFF
--- a/frontend/src/components/admin/DeleteModal.tsx
+++ b/frontend/src/components/admin/DeleteModal.tsx
@@ -14,6 +14,7 @@ type DeleteModalProps = {
   title: string;
   isOpen: boolean;
   body: string;
+  confirmText: string;
   onClose(): void;
   onDelete(): void;
 };
@@ -22,6 +23,7 @@ const DeleteModal = ({
   title,
   isOpen = false,
   body,
+  confirmText,
   onClose = () => {},
   onDelete,
 }: DeleteModalProps): React.ReactElement => {
@@ -74,7 +76,7 @@ const DeleteModal = ({
             fontWeight={700}
             isLoading={isLoading}
           >
-            Delete
+            {confirmText}
           </Button>
         </ModalFooter>
       </ModalContent>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #400 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* To give the current "delete" modal a bit more flexibility to fit in the use case of the remove user modal, which has "remove" as its delete text instead of "delete", we made the text a prop.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. In `default.tsx` used this snippet:
```
const { isOpen, onOpen, onClose } = useDisclosure();

      <Button onClick={onOpen}>Open Modal</Button>
      <DeleteModal
        title="heyo"
        isOpen={isOpen}
        body="this is the body. wow much text!"
        confirmText="Remove"
        onClose={onClose}
        onDelete={() => alert("wow!")}
      />
```

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
