### PR TITLE
AdminUserManagementPage (Created component, routed to /admin/users, queries all users)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ import PasswordResetSuccessPage from "./components/auth/PasswordResetSuccess";
 import NewAccountPage from "./components/pages/NewAccountPage";
 import AccountCreatedPage from "./components/pages/AccountCreatedPage";
 import AdminHomepageComponent from "./components/pages/admin/AdminHomepage";
+import AdminUserManagementPage from "./components/pages/admin/user/AdminUserManagementPage";
 
 // Consts for Hotjar and Google Analytics (this is ok to expose)
 const TRACKING_ID = "G-DF2BP4T8YQ";
@@ -236,6 +237,12 @@ const App = (): React.ReactElement => {
                       path={Routes.ADMIN_SCHEDULE_POSTING_REVIEW_PAGE}
                       authorizedRoles={[Role.Admin]}
                       component={AdminSchedulePostingReviewPage}
+                    />
+                    <PrivateRoute
+                      exact
+                      path={Routes.ADMIN_USER_MANAGMENT_PAGE}
+                      authorizedRoles={[Role.Admin]}
+                      component={AdminUserManagementPage}
                     />
                     <PrivateRoute
                       exact

--- a/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
+++ b/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
@@ -5,6 +5,7 @@ import { gql, useQuery } from "@apollo/client";
 import { VolunteerUserResponseDTO } from "../../../../types/api/UserType";
 import { EmployeeUserResponseDTO } from "../../../../types/api/EmployeeTypes";
 import ErrorModal from "../../../common/ErrorModal";
+import Loading from "../../../common/Loading";
 
 const USERS = gql`
   query AdminUserManagementPage_Users {
@@ -28,7 +29,7 @@ const USERS = gql`
       }
       branches {
         id
-        name
+        nam
       }
     }
   }
@@ -42,17 +43,21 @@ const AdminUserManagementPage = (): React.ReactElement => {
   const [allEmployees, setAllEmployees] = useState<
     EmployeeUserResponseDTO[] | null
   >(null);
-  const { error } = useQuery(USERS, {
+
+  const { loading, error } = useQuery(USERS, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
-      setAllVolunteers(data.postings.employeeUsers);
-      setAllEmployees(data.postings.volunteerUsers);
+      setAllVolunteers(data.employeeUsers);
+      setAllEmployees(data.volunteerUsers);
     },
   });
-  return <Box> {error && <ErrorModal />}</Box>;
+
+  return (
+    <Box>
+      {loading && <Loading />}
+      {error && <ErrorModal />}
+    </Box>
+  );
 };
 
-// const AdminUserManagementPage = (): React.ReactElement => {
-//   return <Box />;
-// };
 export default AdminUserManagementPage;

--- a/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
+++ b/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { useHistory } from "react-router-dom";
-import { Box, HStack } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 import { gql, useQuery } from "@apollo/client";
 import { VolunteerUserResponseDTO } from "../../../../types/api/UserType";
 import { EmployeeUserResponseDTO } from "../../../../types/api/EmployeeTypes";

--- a/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
+++ b/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
+import { Box, HStack } from "@chakra-ui/react";
+import { gql, useQuery } from "@apollo/client";
+import { VolunteerUserResponseDTO } from "../../../../types/api/UserType";
+import { EmployeeUserResponseDTO } from "../../../../types/api/EmployeeTypes";
+import ErrorModal from "../../../common/ErrorModal";
+
+const USERS = gql`
+  query AdminUserManagementPage_Users {
+    employeeUsers {
+      title
+      firstName
+      lastName
+      email
+      phoneNumber
+      branchId
+    }
+    volunteerUsers {
+      firstName
+      lastName
+      email
+      phoneNumber
+      pronouns
+      skills {
+        id
+        name
+      }
+      branches {
+        id
+        name
+      }
+    }
+  }
+`;
+
+const AdminUserManagementPage = (): React.ReactElement => {
+  const [allVolunteers, setAllVolunteers] = useState<
+    VolunteerUserResponseDTO[] | null
+  >(null);
+
+  const [allEmployees, setAllEmployees] = useState<
+    EmployeeUserResponseDTO[] | null
+  >(null);
+  const { error } = useQuery(USERS, {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      setAllVolunteers(data.postings.employeeUsers);
+      setAllEmployees(data.postings.volunteerUsers);
+    },
+  });
+  return <Box> {error && <ErrorModal />}</Box>;
+};
+
+// const AdminUserManagementPage = (): React.ReactElement => {
+//   return <Box />;
+// };
+export default AdminUserManagementPage;


### PR DESCRIPTION
## NOTE
This PR is technically incomplete, 
* The designs for this ticket (see #413), showcase having an emergency contact, and languages, which do not currently exist in the schema.
* In the query, I noticed this different when employeeUsers and volunteerUsers were queried
```
  query AdminUserManagementPage_Users {
    employeeUsers {
      ...
      branchId
    }
    volunteerUsers {
      ...
      branches {
        id
        name
      }
    }
  }
```
Only branchId can be queried for employeeUsers whilst branch info can be seen for volunteerUsers. We should assume that anywhere in which we want to use the branch, it would require the name along with the id, not just the branchId.

## Ticket link
<!-- Please replace with your issue number -->
Closes #413 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created `AdminUserManagementPage.tsx` in `/pages/admin/user`
* Routed page to `/admin/user`
* Added query that queries all user data


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `localhost:3000/admin/users`
2. Check networks tab 
3. To check if error works as intended, change one of the params in the query

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
