### PR TITLE
Admin homepage posting card

### DIFF
--- a/backend/graphql/types/postingType.ts
+++ b/backend/graphql/types/postingType.ts
@@ -9,7 +9,6 @@ const postingType = gql`
   enum PostingStatus {
     DRAFT
     PUBLISHED
-    ARCHIVED
   }
 
   input PostingRequestDTO {

--- a/backend/prisma/migrations/20220620220742_remove_archive_state_from_posting/migration.sql
+++ b/backend/prisma/migrations/20220620220742_remove_archive_state_from_posting/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [ARCHIVED] on the enum `PostingStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "PostingStatus_new" AS ENUM ('DRAFT', 'PUBLISHED');
+ALTER TABLE "postings" ALTER COLUMN "status" TYPE "PostingStatus_new" USING ("status"::text::"PostingStatus_new");
+ALTER TYPE "PostingStatus" RENAME TO "PostingStatus_old";
+ALTER TYPE "PostingStatus_new" RENAME TO "PostingStatus";
+DROP TYPE "PostingStatus_old";
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -60,7 +60,6 @@ enum PostingType {
 enum PostingStatus {
   DRAFT
   PUBLISHED
-  ARCHIVED
 }
 
 enum Role {

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -207,7 +207,7 @@ export type Letters = "A" | "B" | "C" | "D";
 
 export type PostingType = "INDIVIDUAL" | "GROUP";
 
-export type PostingStatus = "DRAFT" | "PUBLISHED" | "ARCHIVED";
+export type PostingStatus = "DRAFT" | "PUBLISHED";
 
 export type NodemailerConfig = {
   service: "gmail";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "react-dom": "^17.0.1",
     "react-ga": "^3.3.0",
     "react-hotjar": "^5.0.0",
+    "react-icons": "^4.4.0",
     "react-json-schema": "^1.2.2",
     "react-jsonschema-form": "^1.8.1",
     "react-router-dom": "^5.2.0",

--- a/frontend/src/components/admin/AdminPostingCard.tsx
+++ b/frontend/src/components/admin/AdminPostingCard.tsx
@@ -19,6 +19,7 @@ import {
 
 import { formatDateStringYear } from "../../utils/DateTimeUtils";
 import { Role } from "../../types/AuthTypes";
+import DeleteModal from "./DeleteModal";
 
 export enum PostingStatus {
   DRAFT = "DRAFT",
@@ -52,91 +53,107 @@ const AdminPostingCard = ({
   numVolunteers,
   navigateToAdminSchedule,
 }: AdminPostingCardProps): React.ReactElement => {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+
   return (
-    <Box
-      bg="white"
-      borderRadius="8px"
-      border="2px solid"
-      borderColor="background.dark"
-      id={id}
-    >
-      <VStack p={8} align="start" spacing="12px" textAlign="left">
-        <HStack w="full" justifyContent="space-between">
-          <Tag>{branchName}</Tag>
-          {role === Role.Admin && (
-            <Menu placement="bottom-end">
-              <MenuButton
-                as={IconButton}
-                aria-label="Options"
-                icon={<Icon as={BsThreeDots} w={6} />}
-                variant="unstyled"
-              />
-              <MenuList shadow="md">
-                <MenuItem>Edit</MenuItem>
-                <MenuItem>Make a copy</MenuItem>
-                <MenuItem>Delete</MenuItem>
-              </MenuList>
-            </Menu>
-          )}
-        </HStack>
-        <Text noOfLines={1} textStyle="heading">
-          {status === PostingStatus.DRAFT && (
-            <Box as="span" mr={1} color="red">
-              [DRAFT]
-            </Box>
-          )}
-          {title}
-        </Text>
-        <HStack spacing={4}>
-          <Box textStyle="caption">
-            <CalendarIcon w={6} pr={2} />
-            {(startDate && endDate) || status === PostingStatus.DRAFT
-              ? `${formatDateStringYear(startDate)} - ${formatDateStringYear(
-                  endDate,
-                )}`
-              : "No date(s) selected"}
-          </Box>
-        </HStack>
-        <HStack>
-          <Box textStyle="caption">
-            <Icon as={BsPeopleFill} w={6} pr={2} />
-            {status === PostingStatus.DRAFT
-              ? "Not accepting registrants"
-              : `${numVolunteers} volunteers`}
-          </Box>
-        </HStack>
-        <Box w="100%" h="100%" mt="16px !important" mb="4px !important">
-          <Divider />
-        </Box>
-        <HStack justifyContent="space-between" w="100%">
-          <Text textStyle="caption" color="text.gray">
-            Deadline:{" "}
-            {status === PostingStatus.PAST ? (
-              <Box as="span" color="red">
-                Closed
-              </Box>
-            ) : (
-              formatDateStringYear(autoClosingDate)
+    <>
+      <DeleteModal
+        title="Delete Posting?"
+        isOpen={isDeleteModalOpen}
+        body={`Are you sure you want to delete "${title}"?`}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onDelete={() => {
+          // TODO: delete posting
+          setIsDeleteModalOpen(false);
+        }}
+      />
+      <Box
+        bg="white"
+        borderRadius="8px"
+        border="2px solid"
+        borderColor="background.dark"
+        id={id}
+      >
+        <VStack p={8} align="start" spacing="12px" textAlign="left">
+          <HStack w="full" justifyContent="space-between">
+            <Tag>{branchName}</Tag>
+            {role === Role.Admin && (
+              <Menu placement="bottom-end">
+                <MenuButton
+                  as={IconButton}
+                  aria-label="Options"
+                  icon={<Icon as={BsThreeDots} w={6} />}
+                  variant="unstyled"
+                />
+                <MenuList shadow="md">
+                  <MenuItem>Edit</MenuItem>
+                  <MenuItem>Make a copy</MenuItem>
+                  <MenuItem onClick={() => setIsDeleteModalOpen(true)}>
+                    Delete
+                  </MenuItem>
+                </MenuList>
+              </Menu>
             )}
+          </HStack>
+          <Text noOfLines={1} textStyle="heading">
+            {status === PostingStatus.DRAFT && (
+              <Box as="span" mr={1} color="red">
+                [DRAFT]
+              </Box>
+            )}
+            {title}
           </Text>
-          {status === PostingStatus.DRAFT ||
-          status === PostingStatus.UNSCHEDULED ? (
-            <Button
-              variant="ghost"
-              disabled={
-                status === PostingStatus.DRAFT
-              } /* TODO: Link to review registrants page */
-            >
-              Review Registrants
-            </Button>
-          ) : (
-            <Button variant="ghost" onClick={navigateToAdminSchedule}>
-              View Schedule
-            </Button>
-          )}
-        </HStack>
-      </VStack>
-    </Box>
+          <HStack spacing={4}>
+            <Box textStyle="caption">
+              <CalendarIcon w={6} pr={2} />
+              {(startDate && endDate) || status === PostingStatus.DRAFT
+                ? `${formatDateStringYear(startDate)} - ${formatDateStringYear(
+                    endDate,
+                  )}`
+                : "No date(s) selected"}
+            </Box>
+          </HStack>
+          <HStack>
+            <Box textStyle="caption">
+              <Icon as={BsPeopleFill} w={6} pr={2} />
+              {status === PostingStatus.DRAFT
+                ? "Not accepting registrants"
+                : `${numVolunteers} volunteers`}
+            </Box>
+          </HStack>
+          <Box w="100%" h="100%" mt="16px !important" mb="4px !important">
+            <Divider />
+          </Box>
+          <HStack justifyContent="space-between" w="100%">
+            <Text textStyle="caption" color="text.gray">
+              Deadline:{" "}
+              {status === PostingStatus.PAST ? (
+                <Box as="span" color="red">
+                  Closed
+                </Box>
+              ) : (
+                formatDateStringYear(autoClosingDate)
+              )}
+            </Text>
+            {status === PostingStatus.DRAFT ||
+            status === PostingStatus.UNSCHEDULED ? (
+              <Button
+                variant="ghost"
+                disabled={
+                  status === PostingStatus.DRAFT
+                } /* TODO: Link to review registrants page */
+              >
+                Review Registrants
+              </Button>
+            ) : (
+              <Button variant="ghost" onClick={navigateToAdminSchedule}>
+                View Schedule
+              </Button>
+            )}
+          </HStack>
+        </VStack>
+      </Box>
+    </>
   );
 };
 

--- a/frontend/src/components/admin/AdminPostingCard.tsx
+++ b/frontend/src/components/admin/AdminPostingCard.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { CalendarIcon } from "@chakra-ui/icons";
+import { BsPeopleFill, BsThreeDots } from "react-icons/bs";
+import {
+  Text,
+  Box,
+  VStack,
+  HStack,
+  Divider,
+  Button,
+  Tag,
+  Icon,
+  Menu,
+  MenuButton,
+  IconButton,
+  MenuList,
+  MenuItem,
+} from "@chakra-ui/react";
+
+import { formatDateStringYear } from "../../utils/DateTimeUtils";
+import { Role } from "../../types/AuthTypes";
+
+export enum PostingStatus {
+  DRAFT = "DRAFT",
+  SCHEDULED = "SCHEDULED",
+  UNSCHEDULED = "UNSCHEDULED",
+  PAST = "PAST",
+}
+
+type AdminPostingCardProps = {
+  status: PostingStatus;
+  id: string;
+  role: Role;
+  title: string;
+  startDate: string;
+  endDate: string;
+  autoClosingDate: string;
+  branchName: string;
+  numVolunteers: number;
+  navigateToAdminSchedule?: () => void;
+};
+
+const AdminPostingCard = ({
+  status,
+  id,
+  role,
+  title,
+  startDate,
+  endDate,
+  autoClosingDate,
+  branchName,
+  numVolunteers,
+  navigateToAdminSchedule,
+}: AdminPostingCardProps): React.ReactElement => {
+  return (
+    <Box
+      bg="white"
+      borderRadius="8px"
+      border="2px solid"
+      borderColor="background.dark"
+      id={id}
+    >
+      <VStack p={8} align="start" spacing="12px" textAlign="left">
+        <HStack w="full" justifyContent="space-between">
+          <Tag>{branchName}</Tag>
+          {role === Role.Admin && (
+            <Menu placement="bottom-end">
+              <MenuButton
+                as={IconButton}
+                aria-label="Options"
+                icon={<Icon as={BsThreeDots} w={6} />}
+                variant="unstyled"
+              />
+              <MenuList shadow="md">
+                <MenuItem>Edit</MenuItem>
+                <MenuItem>Make a copy</MenuItem>
+                <MenuItem>Delete</MenuItem>
+              </MenuList>
+            </Menu>
+          )}
+        </HStack>
+        <Text noOfLines={1} textStyle="heading">
+          {status === PostingStatus.DRAFT && (
+            <Box as="span" mr={1} color="red">
+              [DRAFT]
+            </Box>
+          )}
+          {title}
+        </Text>
+        <HStack spacing={4}>
+          <Box textStyle="caption">
+            <CalendarIcon w={6} pr={2} />
+            {(startDate && endDate) || status === PostingStatus.DRAFT
+              ? `${formatDateStringYear(startDate)} - ${formatDateStringYear(
+                  endDate,
+                )}`
+              : "No date(s) selected"}
+          </Box>
+        </HStack>
+        <HStack>
+          <Box textStyle="caption">
+            <Icon as={BsPeopleFill} w={6} pr={2} />
+            {status === PostingStatus.DRAFT
+              ? "Not accepting registrants"
+              : `${numVolunteers} volunteers`}
+          </Box>
+        </HStack>
+        <Box w="100%" h="100%" mt="16px !important" mb="4px !important">
+          <Divider />
+        </Box>
+        <HStack justifyContent="space-between" w="100%">
+          <Text textStyle="caption" color="text.gray">
+            Deadline:{" "}
+            {status === PostingStatus.PAST ? (
+              <Box as="span" color="red">
+                Closed
+              </Box>
+            ) : (
+              formatDateStringYear(autoClosingDate)
+            )}
+          </Text>
+          {status === PostingStatus.DRAFT ||
+          status === PostingStatus.UNSCHEDULED ? (
+            <Button
+              variant="ghost"
+              disabled={
+                status === PostingStatus.DRAFT
+              } /* TODO: Link to review registrants page */
+            >
+              Review Registrants
+            </Button>
+          ) : (
+            <Button variant="ghost" onClick={navigateToAdminSchedule}>
+              View Schedule
+            </Button>
+          )}
+        </HStack>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AdminPostingCard;

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -106,7 +106,9 @@ const Default = (): React.ReactElement => {
                 status={getPostingStatus(posting)}
                 role={authenticatedUser.role}
                 id={posting.id}
-                title={posting.title}
+                title={
+                  posting.title === "" ? "Untitled posting" : posting.title
+                }
                 startDate={posting.startDate}
                 endDate={posting.endDate}
                 autoClosingDate={posting.autoClosingDate}

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -102,34 +102,6 @@ const Default = (): React.ReactElement => {
         >
           Create Posting
         </Button>
-        {postings?.map((posting) => (
-          <Box key={posting.id} pb="24px">
-            <PostingCard
-              key={posting.id}
-              id={posting.id}
-              skills={posting.skills}
-              title={posting.title}
-              startDate={posting.startDate}
-              endDate={posting.endDate}
-              autoClosingDate={posting.autoClosingDate}
-              description={posting.description}
-              branchName={posting.branch.name}
-              type={
-                isEventPosting(
-                  new Date(posting.startDate),
-                  new Date(posting.endDate),
-                )
-                  ? "EVENT"
-                  : "OPPORTUNITY"
-              }
-              shifts={posting.shifts}
-              navigateToDetails={() => navigateToDetails(posting.id)}
-              navigateToAdminSchedule={() =>
-                navigateToAdminSchedule(posting.id)
-              }
-            />
-          </Box>
-        ))}
       </ButtonGroup>
       <SimpleGrid columns={2} spacing={4}>
         {authenticatedUser &&

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -17,8 +17,7 @@ import AuthContext from "../../contexts/AuthContext";
 import { Role } from "../../types/AuthTypes";
 import { PostingResponseDTO } from "../../types/api/PostingTypes";
 import AdminPostingCard, { PostingStatus } from "../admin/AdminPostingCard";
-import { isEventPosting, isPast } from "../../utils/DateTimeUtils";
-import PostingCard from "../volunteer/PostingCard";
+import { isPast } from "../../utils/DateTimeUtils";
 
 const POSTINGS = gql`
   query Default_postings {
@@ -66,11 +65,6 @@ const Default = (): React.ReactElement => {
   if (authenticatedUser?.role === Role.Volunteer) {
     return <Redirect to={Routes.VOLUNTEER_POSTINGS_PAGE} />;
   }
-
-  const navigateToDetails = (id: string) => {
-    const route = generatePath(Routes.ADMIN_POSTING_DETAILS, { id });
-    history.push(route);
-  };
 
   const navigateToAdminSchedule = (id: string) => {
     const route = generatePath(Routes.ADMIN_SCHEDULE_POSTING_PAGE, { id });

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -1,6 +1,13 @@
 import React, { useContext, useState } from "react";
 import { generatePath, Redirect, useHistory } from "react-router-dom";
-import { Box, Button, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Container,
+  SimpleGrid,
+  Text,
+} from "@chakra-ui/react";
 import { gql, useQuery } from "@apollo/client";
 
 import Logout from "../auth/Logout";
@@ -9,8 +16,9 @@ import * as Routes from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
 import { Role } from "../../types/AuthTypes";
 import { PostingResponseDTO } from "../../types/api/PostingTypes";
+import AdminPostingCard, { PostingStatus } from "../admin/AdminPostingCard";
+import { isEventPosting, isPast } from "../../utils/DateTimeUtils";
 import PostingCard from "../volunteer/PostingCard";
-import { isEventPosting } from "../../utils/DateTimeUtils";
 
 const POSTINGS = gql`
   query Default_postings {
@@ -34,15 +42,14 @@ const POSTINGS = gql`
       description
       startDate
       endDate
+      numVolunteers
       autoClosingDate
+      status
     }
   }
 `;
 
-type Posting = Omit<
-  PostingResponseDTO,
-  "employees" | "type" | "numVolunteers" | "status"
->;
+type Posting = Omit<PostingResponseDTO, "employees" | "type">;
 
 const Default = (): React.ReactElement => {
   const history = useHistory();
@@ -69,10 +76,24 @@ const Default = (): React.ReactElement => {
     const route = generatePath(Routes.ADMIN_SCHEDULE_POSTING_PAGE, { id });
     history.push(route);
   };
+
+  const getPostingStatus = (posting: Posting): PostingStatus => {
+    if (posting.status === "DRAFT") {
+      return PostingStatus.DRAFT;
+    }
+    if (isPast(posting.autoClosingDate)) {
+      return PostingStatus.PAST;
+    }
+    if (posting.shifts.length === 0) {
+      return PostingStatus.UNSCHEDULED;
+    }
+    return PostingStatus.SCHEDULED;
+  };
+
   return (
-    <div style={{ textAlign: "center", paddingTop: "20px" }}>
+    <Container maxW="container.xl" textAlign="center" mt={8}>
       <Text textStyle="display-large">Welcome to Sistering</Text>
-      <div className="btn-group" style={{ paddingRight: "10px" }}>
+      <ButtonGroup m={8}>
         <Logout />
         <Button
           onClick={() =>
@@ -81,34 +102,58 @@ const Default = (): React.ReactElement => {
         >
           Create Posting
         </Button>
-      </div>
-      {postings?.map((posting) => (
-        <Box key={posting.id} pb="24px">
-          <PostingCard
-            key={posting.id}
-            id={posting.id}
-            skills={posting.skills}
-            title={posting.title}
-            startDate={posting.startDate}
-            endDate={posting.endDate}
-            autoClosingDate={posting.autoClosingDate}
-            description={posting.description}
-            branchName={posting.branch.name}
-            type={
-              isEventPosting(
-                new Date(posting.startDate),
-                new Date(posting.endDate),
-              )
-                ? "EVENT"
-                : "OPPORTUNITY"
-            }
-            shifts={posting.shifts}
-            navigateToDetails={() => navigateToDetails(posting.id)}
-            navigateToAdminSchedule={() => navigateToAdminSchedule(posting.id)}
-          />
-        </Box>
-      ))}
-    </div>
+        {postings?.map((posting) => (
+          <Box key={posting.id} pb="24px">
+            <PostingCard
+              key={posting.id}
+              id={posting.id}
+              skills={posting.skills}
+              title={posting.title}
+              startDate={posting.startDate}
+              endDate={posting.endDate}
+              autoClosingDate={posting.autoClosingDate}
+              description={posting.description}
+              branchName={posting.branch.name}
+              type={
+                isEventPosting(
+                  new Date(posting.startDate),
+                  new Date(posting.endDate),
+                )
+                  ? "EVENT"
+                  : "OPPORTUNITY"
+              }
+              shifts={posting.shifts}
+              navigateToDetails={() => navigateToDetails(posting.id)}
+              navigateToAdminSchedule={() =>
+                navigateToAdminSchedule(posting.id)
+              }
+            />
+          </Box>
+        ))}
+      </ButtonGroup>
+      <SimpleGrid columns={2} spacing={4}>
+        {authenticatedUser &&
+          postings?.map((posting) => (
+            <Box key={posting.id} pb="24px">
+              <AdminPostingCard
+                key={posting.id}
+                status={getPostingStatus(posting)}
+                role={authenticatedUser.role}
+                id={posting.id}
+                title={posting.title}
+                startDate={posting.startDate}
+                endDate={posting.endDate}
+                autoClosingDate={posting.autoClosingDate}
+                branchName={posting.branch.name}
+                numVolunteers={posting.numVolunteers}
+                navigateToAdminSchedule={() =>
+                  navigateToAdminSchedule(posting.id)
+                }
+              />
+            </Box>
+          ))}
+      </SimpleGrid>
+    </Container>
   );
 };
 

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -13,7 +13,10 @@ import {
 
 import moment from "moment";
 import RichTextDisplay from "../common/RichText/RichTextDisplay";
-import { formatDateStringYear } from "../../utils/DateTimeUtils";
+import {
+  formatDateStringYear,
+  formatTimeHourMinutes,
+} from "../../utils/DateTimeUtils";
 import { SkillResponseDTO } from "../../types/api/SkillTypes";
 import { PostingRecurrenceType } from "../../types/PostingTypes";
 import { ShiftDTO } from "../../types/api/ShiftTypes";
@@ -84,14 +87,20 @@ const PostingCard = ({
         </Text>
         <HStack spacing={4}>
           <Text textStyle="caption" noOfLines={2}>
-            <TimeIcon w={6} pr={2} />
-            See Posting Details
+            <TimeIcon w={4} pr={1} />
+            {type === "OPPORTUNITY"
+              ? "See posting details"
+              : `${formatTimeHourMinutes(
+                  new Date(eventFirstTime),
+                )} - ${formatTimeHourMinutes(new Date(eventLatestTime))}`}
           </Text>
           <Box textStyle="caption">
-            <CalendarIcon w={6} pr={2} />
-            {`${formatDateStringYear(startDate)} - ${formatDateStringYear(
-              endDate,
-            )}`}
+            <CalendarIcon w={4} pr={1} />
+            {type === "OPPORTUNITY"
+              ? `${formatDateStringYear(startDate)} - ${formatDateStringYear(
+                  endDate,
+                )}`
+              : formatDateStringYear(startDate)}
           </Box>
         </HStack>
         <Box textStyle="body-regular" noOfLines={2}>

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -13,10 +13,7 @@ import {
 
 import moment from "moment";
 import RichTextDisplay from "../common/RichText/RichTextDisplay";
-import {
-  formatDateStringYear,
-  formatTimeHourMinutes,
-} from "../../utils/DateTimeUtils";
+import { formatDateStringYear } from "../../utils/DateTimeUtils";
 import { SkillResponseDTO } from "../../types/api/SkillTypes";
 import { PostingRecurrenceType } from "../../types/PostingTypes";
 import { ShiftDTO } from "../../types/api/ShiftTypes";

--- a/frontend/src/components/volunteer/PostingCard.tsx
+++ b/frontend/src/components/volunteer/PostingCard.tsx
@@ -82,23 +82,19 @@ const PostingCard = ({
     >
       <VStack px="40px" py="36px" align="start" spacing="12px">
         <Tag>{branchName}</Tag>
-        <Text textStyle="heading">{title}</Text>
+        <Text noOfLines={1} textStyle="heading">
+          {title}
+        </Text>
         <HStack spacing={4}>
           <Text textStyle="caption" noOfLines={2}>
-            <TimeIcon w={4} pr={1} />
-            {type === "OPPORTUNITY"
-              ? "See posting details"
-              : `${formatTimeHourMinutes(
-                  new Date(eventFirstTime),
-                )} - ${formatTimeHourMinutes(new Date(eventLatestTime))}`}
+            <TimeIcon w={6} pr={2} />
+            See Posting Details
           </Text>
           <Box textStyle="caption">
-            <CalendarIcon w={4} pr={1} />
-            {type === "OPPORTUNITY"
-              ? `${formatDateStringYear(startDate)} - ${formatDateStringYear(
-                  endDate,
-                )}`
-              : formatDateStringYear(startDate)}
+            <CalendarIcon w={6} pr={2} />
+            {`${formatDateStringYear(startDate)} - ${formatDateStringYear(
+              endDate,
+            )}`}
           </Box>
         </HStack>
         <Box textStyle="body-regular" noOfLines={2}>

--- a/frontend/src/types/PostingTypes.ts
+++ b/frontend/src/types/PostingTypes.ts
@@ -1,6 +1,6 @@
 export type PostingType = "INDIVIDUAL" | "GROUP";
 
-export type PostingStatus = "DRAFT" | "PUBLISHED" | "ARCHIVED";
+export type PostingStatus = "DRAFT" | "PUBLISHED";
 
 export type RecurrenceInterval = "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "NONE";
 

--- a/frontend/src/types/api/PostingTypes.ts
+++ b/frontend/src/types/api/PostingTypes.ts
@@ -5,7 +5,12 @@ import { EmployeeUserResponseDTO } from "./EmployeeTypes";
 
 export type PostingType = "INDIVIDUAL" | "GROUP";
 
-export type PostingStatus = "DRAFT" | "PUBLISHED" | "ARCHIVED";
+// Draft --> Draft
+// Published && Date > current --> Past
+// Published && Date <= current && shifts.length == 0 --> Unscheduled
+// Published && Date <= current && shifts.length > 0 --> Scheduled
+
+export type PostingStatus = "DRAFT" | "PUBLISHED";
 
 export type PostingDTO = {
   id: string;

--- a/frontend/src/types/api/PostingTypes.ts
+++ b/frontend/src/types/api/PostingTypes.ts
@@ -5,11 +5,6 @@ import { EmployeeUserResponseDTO } from "./EmployeeTypes";
 
 export type PostingType = "INDIVIDUAL" | "GROUP";
 
-// Draft --> Draft
-// Published && Date > current --> Past
-// Published && Date <= current && shifts.length == 0 --> Unscheduled
-// Published && Date <= current && shifts.length > 0 --> Scheduled
-
 export type PostingStatus = "DRAFT" | "PUBLISHED";
 
 export type PostingDTO = {

--- a/frontend/src/utils/DateTimeUtils.ts
+++ b/frontend/src/utils/DateTimeUtils.ts
@@ -182,3 +182,13 @@ export const isEventPosting = (startDate: Date, endDate: Date): boolean => {
   // this logic to be for Toronto time only
   return moment(startDate).isSame(endDate, "day");
 };
+
+/**
+ * Returns true if the date is in the past
+ * @param date a date string in YYYY-MM-DD format
+ * @returns true if the date is in the past
+ * @returns false if the date is in the future
+ */
+export const isPast = (date: string): boolean => {
+  return moment(date).isBefore(moment().toDate());
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10876,6 +10876,11 @@ react-icons@^3.10.0:
   dependencies:
     camelcase "^5.0.0"
 
+react-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
+  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+
 "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #343 
Closes #344 

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implemented the Admin / Super Admin posting cards
* Rendering depends on the Posting's states, see [Figma](https://www.figma.com/file/TWJTNWjK75A6VgSisySTLe/Sistering-%2F-Admin-Experience?node-id=1420%3A39607)
* Backend posting status doesn't correspond with frontend, so they are resolved as discussed w/ Rickson. See getPostingStatus() method for details.
* Preview:
<img width="1439" alt="Screen Shot 2022-06-25 at 7 29 18 PM" src="https://user-images.githubusercontent.com/47638847/175793624-5b40397a-f301-4192-8be9-b75aa7efc364.png">


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to http://localhost:3000/ with an admin account (this should also work for employees, but backend currently unauthorizes employees to retrieve postings).
2. Check that the cards render according to designs. Can try adding more postings with different statuses.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness of rendering / matches designs


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
