### PR TITLE
Polish upcoming volunteer shifts table to match design

### DIFF
--- a/frontend/src/components/volunteer/shifts/VolunteerPendingShiftsTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerPendingShiftsTableRow.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Tr, Td, Text, Button, Table, Tbody } from "@chakra-ui/react";
+import { generatePath, useHistory } from "react-router-dom";
+
+import { formatDateMonthDay } from "../../../utils/DateTimeUtils";
+import { VOLUNTEER_POSTING_DETAILS } from "../../../constants/Routes";
+
+type VolunteerShiftsTableRowProps = {
+  postingName: string;
+  postingId: string;
+  deadline: string;
+};
+
+const VolunteerShiftsTableRow: React.FC<VolunteerShiftsTableRowProps> = ({
+  postingName,
+  postingId,
+  deadline,
+}: VolunteerShiftsTableRowProps) => {
+  const history = useHistory();
+
+  return (
+    <Table variant="brand">
+      <Tbody>
+        <Tr>
+          <Td>
+            <Text>{postingName}</Text>
+          </Td>
+          <Td>
+            <Text>Deadline: {formatDateMonthDay(deadline)}</Text>
+          </Td>
+          <Td>
+            <Button
+              variant="link"
+              onClick={() =>
+                history.push(
+                  generatePath(VOLUNTEER_POSTING_DETAILS, { id: postingId }),
+                )
+              }
+            >
+              Go To Posting
+            </Button>
+          </Td>
+        </Tr>
+      </Tbody>
+    </Table>
+  );
+};
+
+export default VolunteerShiftsTableRow;

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTableEmptyState.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTableEmptyState.tsx
@@ -1,0 +1,40 @@
+import {
+  Button,
+  Container,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Tr,
+  VStack,
+} from "@chakra-ui/react";
+import React from "react";
+import { useHistory } from "react-router-dom";
+import { VOLUNTEER_POSTINGS_PAGE } from "../../../constants/Routes";
+
+const VolunteerShiftsTableEmptyState = (): React.ReactElement => {
+  const history = useHistory();
+  return (
+    <Table variant="brand">
+      <Tbody>
+        <Tr>
+          <Td>
+            <Container maxW="container.xl" minH="90vh">
+              <VStack pt="25%">
+                <Text color="text.gray">No shifts to show</Text>
+                <Button
+                  variant="outline"
+                  onClick={() => history.push(VOLUNTEER_POSTINGS_PAGE)}
+                >
+                  Browse volunteer postings
+                </Button>
+              </VStack>
+            </Container>
+          </Td>
+        </Tr>
+      </Tbody>
+    </Table>
+  );
+};
+
+export default VolunteerShiftsTableEmptyState;

--- a/frontend/src/components/volunteer/shifts/VolunteerUpcomingShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerUpcomingShiftsTable.tsx
@@ -1,0 +1,75 @@
+import { Table, Tbody, Td, Text, Tr } from "@chakra-ui/react";
+import React, { useEffect, useState } from "react";
+import moment from "moment";
+import NoShiftsAvailableTableRow from "./NoShiftsAvailableTableRow";
+import { ShiftSignupPostingResponseDTO } from "../../../types/api/ShiftSignupTypes";
+import VolunteerUpcomingShiftsTableRow from "./VolunteerUpcomingShiftsTableRow";
+
+type VolunteerUpcomingShiftsTableProps = {
+  shifts: ShiftSignupPostingResponseDTO[];
+};
+
+const VolunteerUpcomingShiftsTable = ({
+  shifts,
+}: VolunteerUpcomingShiftsTableProps): React.ReactElement => {
+  const [orderedDates, setOrderedDates] = useState<Date[]>(
+    shifts.map((shift) => new Date(shift.shiftStartTime)).sort(),
+  );
+
+  useEffect(() => {
+    setOrderedDates(
+      shifts.map((shift) => new Date(shift.shiftStartTime)).sort(),
+    );
+  }, [shifts]);
+
+  return (
+    <Table variant="brand">
+      {/* We should iterate over all ordered dates */}
+      {orderedDates.map((date) => {
+        const shiftsOfDate = shifts.filter((shift) =>
+          moment(shift.shiftStartTime).isSame(moment(date), "day"),
+        );
+
+        return (
+          <Tbody key={date.getTime()}>
+            <Tr bgColor="background.light">
+              <Td>
+                <Text textStyle="body-bold">
+                  {date.toLocaleDateString("en-US", {
+                    weekday: "long",
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </Text>
+              </Td>
+              <Td />
+              <Td />
+            </Tr>
+            {shifts.length < 1 ? (
+              <Tr>
+                <Td>
+                  <NoShiftsAvailableTableRow />
+                </Td>
+              </Tr>
+            ) : (
+              shiftsOfDate.map((shift, index) => {
+                return (
+                  <VolunteerUpcomingShiftsTableRow
+                    key={`${shift.shiftId}-${date.getTime()}-${index}`}
+                    postingName={shift.postingTitle}
+                    postingId={shift.postingId}
+                    startTime={shift.shiftStartTime}
+                    endTime={shift.shiftEndTime}
+                  />
+                );
+              })
+            )}
+          </Tbody>
+        );
+      })}
+    </Table>
+  );
+};
+
+export default VolunteerUpcomingShiftsTable;

--- a/frontend/src/components/volunteer/shifts/VolunteerUpcomingShiftsTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerUpcomingShiftsTableRow.tsx
@@ -5,27 +5,22 @@ import { generatePath, useHistory } from "react-router-dom";
 import {
   getElapsedHours,
   formatTimeHourMinutes,
-  formatDateMonthDay,
 } from "../../../utils/DateTimeUtils";
-import { ShiftSignupStatus } from "../../../types/api/ShiftSignupTypes";
 import { VOLUNTEER_POSTING_DETAILS } from "../../../constants/Routes";
 
-type VolunteerShiftsTableRowProps = {
+type VolunteerUpcomingShiftsTableRowProps = {
   postingName: string;
   postingId: string;
   startTime: string;
   endTime: string;
-  deadline: string;
-  status: ShiftSignupStatus;
 };
-const VolunteerShiftsTableRow: React.FC<VolunteerShiftsTableRowProps> = ({
+
+const VolunteerUpcomingShiftsTableRow: React.FC<VolunteerUpcomingShiftsTableRowProps> = ({
   postingName,
   postingId,
   startTime,
   endTime,
-  deadline,
-  status,
-}: VolunteerShiftsTableRowProps) => {
+}: VolunteerUpcomingShiftsTableRowProps) => {
   const history = useHistory();
 
   const start = new Date(startTime);
@@ -40,26 +35,12 @@ const VolunteerShiftsTableRow: React.FC<VolunteerShiftsTableRowProps> = ({
 
   return (
     <Tr>
-      {/* eslint-disable-next-line no-nested-ternary */}
-      {status === "PUBLISHED" ? (
-        <>
-          <Td>
-            <Text>{`${time} ${duration}`}</Text>
-          </Td>
-          <Td>
-            <Text>{postingName}</Text>
-          </Td>
-        </>
-      ) : status === "CONFIRMED" || status === "PENDING" ? (
-        <>
-          <Td>
-            <Text>{postingName}</Text>
-          </Td>
-          <Td>
-            <Text>Deadline: {formatDateMonthDay(deadline)}</Text>
-          </Td>
-        </>
-      ) : null}
+      <Td>
+        <Text>{`${time} ${duration}`}</Text>
+      </Td>
+      <Td>
+        <Text>{postingName}</Text>
+      </Td>
       <Td>
         <Button
           variant="link"
@@ -76,4 +57,4 @@ const VolunteerShiftsTableRow: React.FC<VolunteerShiftsTableRowProps> = ({
   );
 };
 
-export default VolunteerShiftsTableRow;
+export default VolunteerUpcomingShiftsTableRow;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #433


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Separate unrelated tables under `VolunteerShiftsTable`
* Create a new `VolunteerUpcomingShiftsTable` based on the existing `VolunteerAvailbilityTable`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/volunteer/shifts ensure the tables on the my shifts and pending confirmation tabs looks good on empty case and non-empty case

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness and cleanliness

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
