### PR TITLE
Deduplicate postings in requests pending table

### DIFF
--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -64,6 +64,8 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
     setFilter(value);
   };
 
+  const uniquePostingIds = new Set();
+
   return (
     <Box
       bgColor="background.white"
@@ -96,17 +98,25 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       <Table variant="brand">
         <Tbody>
           {displayShifts.length > 0 ? (
-            displayShifts.map((shift, idx) => (
-              <VolunteerShiftsTableRow
-                key={idx}
-                postingName={shift.postingTitle}
-                postingId={shift.postingId}
-                startTime={shift.shiftStartTime}
-                endTime={shift.shiftEndTime}
-                deadline={shift.autoClosingDate}
-                status={shift.status}
-              />
-            ))
+            displayShifts
+              .filter((shift) => {
+                if (uniquePostingIds.has(shift.postingId)) {
+                  return false;
+                }
+                uniquePostingIds.add(shift.postingId);
+                return true;
+              })
+              .map((shift, idx) => (
+                <VolunteerShiftsTableRow
+                  key={idx}
+                  postingName={shift.postingTitle}
+                  postingId={shift.postingId}
+                  startTime={shift.shiftStartTime}
+                  endTime={shift.shiftEndTime}
+                  deadline={shift.autoClosingDate}
+                  status={shift.status}
+                />
+              ))
           ) : (
             // empty state
             <Tr>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #434 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* There's a set (state not needed, just a set) called `uniquePostingIds`
* Before mapping `displayShifts`, we filter it by checking if a shift's posting id is in the set
* If it is in the set, don't keep it, otherwise keep it and add the posting id to the set to avoid further duplicates
* This filtered `displayShifts` is then mapped as before


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login as a volunteer
2. Navigate to the "My Shifts" tab
3. Click the Requests Pending Confirmation tab, and ensure there are no duplicate postings


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* My approach (from what I can tell) is slightly different than what was outlined for me in the ticket, under Technical. I didn't think it was necessary to create any new objects/state for this bug but please review accordingly.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
