### PR TITLE
Deduplicate postings in requests pending table

### DIFF
--- a/frontend/src/components/volunteer/shifts/VolunteerPendingShiftsTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerPendingShiftsTableRow.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Tr, Td, Text, Button, Table, Tbody } from "@chakra-ui/react";
+import { Tr, Td, Text, Button } from "@chakra-ui/react";
 import { generatePath, useHistory } from "react-router-dom";
 
 import { formatDateMonthDay } from "../../../utils/DateTimeUtils";
@@ -19,8 +19,6 @@ const VolunteerShiftsTableRow: React.FC<VolunteerShiftsTableRowProps> = ({
   const history = useHistory();
 
   return (
-    <Table variant="brand">
-      <Tbody>
         <Tr>
           <Td>
             <Text>{postingName}</Text>
@@ -41,8 +39,6 @@ const VolunteerShiftsTableRow: React.FC<VolunteerShiftsTableRowProps> = ({
             </Button>
           </Td>
         </Tr>
-      </Tbody>
-    </Table>
   );
 };
 

--- a/frontend/src/components/volunteer/shifts/VolunteerPendingShiftsTableRow.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerPendingShiftsTableRow.tsx
@@ -19,26 +19,26 @@ const VolunteerShiftsTableRow: React.FC<VolunteerShiftsTableRowProps> = ({
   const history = useHistory();
 
   return (
-        <Tr>
-          <Td>
-            <Text>{postingName}</Text>
-          </Td>
-          <Td>
-            <Text>Deadline: {formatDateMonthDay(deadline)}</Text>
-          </Td>
-          <Td>
-            <Button
-              variant="link"
-              onClick={() =>
-                history.push(
-                  generatePath(VOLUNTEER_POSTING_DETAILS, { id: postingId }),
-                )
-              }
-            >
-              Go To Posting
-            </Button>
-          </Td>
-        </Tr>
+    <Tr>
+      <Td>
+        <Text>{postingName}</Text>
+      </Td>
+      <Td>
+        <Text>Deadline: {formatDateMonthDay(deadline)}</Text>
+      </Td>
+      <Td>
+        <Button
+          variant="link"
+          onClick={() =>
+            history.push(
+              generatePath(VOLUNTEER_POSTING_DETAILS, { id: postingId }),
+            )
+          }
+        >
+          Go To Posting
+        </Button>
+      </Td>
+    </Tr>
   );
 };
 

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -46,7 +46,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
         return true;
       }
       return moment().isSame(moment(shift.autoClosingDate), filter);
-  });
+    });
 
   const changeFilter = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value: FilterType = e.target.value as FilterType;

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -61,7 +61,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
     }
     uniquePostingIds.add(shift.postingId);
     return true;
-  })
+  });
 
   return (
     <Box

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -54,6 +54,8 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
     setFilter(value);
   };
 
+  const uniquePostingIds = new Set();
+
   return (
     <Box
       bgColor="background.white"
@@ -88,14 +90,22 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       ) : !isShowUpcomingShifts && pendingShifts.length > 0 ? (
         <Table variant="brand">
           <Tbody>
-            {pendingShifts.map((shift, idx) => (
-              <VolunteerPendingShiftsTableRow
-                key={idx}
-                postingName={shift.postingTitle}
-                postingId={shift.postingId}
-                deadline={shift.autoClosingDate}
-              />
-            ))}
+            {pendingShifts
+              .filter((shift) => {
+                if (uniquePostingIds.has(shift.postingId)) {
+                  return false;
+                }
+                uniquePostingIds.add(shift.postingId);
+                return true;
+              })
+              .map((shift, idx) => (
+                <VolunteerPendingShiftsTableRow
+                  key={idx}
+                  postingName={shift.postingTitle}
+                  postingId={shift.postingId}
+                  deadline={shift.autoClosingDate}
+                />
+              ))}
           </Tbody>
         </Table>
       ) : (

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -104,7 +104,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
                 postingId={shift.postingId}
                 deadline={shift.autoClosingDate}
               />
-              ))}
+            ))}
           </Tbody>
         </Table>
       ) : (

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -11,7 +11,6 @@ import {
   Tbody,
 } from "@chakra-ui/react";
 import moment from "moment";
-import { useHistory } from "react-router-dom";
 import { ShiftSignupPostingResponseDTO } from "../../../types/api/ShiftSignupTypes";
 import { FilterType } from "../../../types/DateFilterTypes";
 import VolunteerUpcomingShiftsTable from "./VolunteerUpcomingShiftsTable";
@@ -26,7 +25,6 @@ type VolunteerShiftsTableProps = {
 const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
   shifts,
 }: VolunteerShiftsTableProps) => {
-  const history = useHistory();
   const [filter, setFilter] = useState<FilterType>("week");
   const [isShowUpcomingShifts, setIsShowUpcomingShifts] = useState(true);
 
@@ -38,6 +36,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       }
       return moment().isSame(moment(shift.shiftStartTime), filter);
     });
+
   const pendingShifts = shifts
     .filter(
       (shift) => shift.status === "PENDING" || shift.status === "CONFIRMED",
@@ -47,7 +46,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
         return true;
       }
       return moment().isSame(moment(shift.autoClosingDate), filter);
-    });
+  });
 
   const changeFilter = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value: FilterType = e.target.value as FilterType;
@@ -55,6 +54,14 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
   };
 
   const uniquePostingIds = new Set();
+
+  const uniquePostings = pendingShifts.filter((shift) => {
+    if (uniquePostingIds.has(shift.postingId)) {
+      return false;
+    }
+    uniquePostingIds.add(shift.postingId);
+    return true;
+  })
 
   return (
     <Box
@@ -90,21 +97,13 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       ) : !isShowUpcomingShifts && pendingShifts.length > 0 ? (
         <Table variant="brand">
           <Tbody>
-            {pendingShifts
-              .filter((shift) => {
-                if (uniquePostingIds.has(shift.postingId)) {
-                  return false;
-                }
-                uniquePostingIds.add(shift.postingId);
-                return true;
-              })
-              .map((shift, idx) => (
-                <VolunteerPendingShiftsTableRow
-                  key={idx}
-                  postingName={shift.postingTitle}
-                  postingId={shift.postingId}
-                  deadline={shift.autoClosingDate}
-                />
+            {uniquePostings.map((shift, idx) => (
+              <VolunteerPendingShiftsTableRow
+                key={idx}
+                postingName={shift.postingTitle}
+                postingId={shift.postingId}
+                deadline={shift.autoClosingDate}
+              />
               ))}
           </Tbody>
         </Table>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #434 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* There's a new set (state not needed, just a set) called `uniquePostingIds`
* Before mapping `pendingShifts`, we filter it by checking if a shift's posting id is in the set
* If it is in the set, don't keep it as it is a duplicate, otherwise keep it and add the posting id to the set to avoid further duplicates
* This filtered `pendingShifts` is then mapped as before


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login as a volunteer (sistering+volunteer1@uwblueprint.org would work)
2. Navigate to the "My Shifts" tab
3. Click the Requests Pending Confirmation tab, and ensure there are no duplicate postings (i.e. no duplicate "Croissant Making" shifts)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* My approach (from what I can tell) is slightly different than what was outlined for me in the ticket, under Technical. I didn't think it was necessary to create any new objects/state for this bug but please review accordingly.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
