### PR TITLE
Add conditions to render event vs regular postings on postin cards

### DIFF
--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -10,6 +10,7 @@ import AuthContext from "../../contexts/AuthContext";
 import { Role } from "../../types/AuthTypes";
 import { PostingResponseDTO } from "../../types/api/PostingTypes";
 import PostingCard from "../volunteer/PostingCard";
+import { isEventPosting } from "../../utils/DateTimeUtils";
 
 const POSTINGS = gql`
   query Default_postings {
@@ -23,6 +24,12 @@ const POSTINGS = gql`
         id
         name
       }
+      shifts {
+        id
+        postingId
+        startTime
+        endTime
+      }
       title
       description
       startDate
@@ -34,7 +41,7 @@ const POSTINGS = gql`
 
 type Posting = Omit<
   PostingResponseDTO,
-  "shifts" | "employees" | "type" | "numVolunteers" | "status"
+  "employees" | "type" | "numVolunteers" | "status"
 >;
 
 const Default = (): React.ReactElement => {
@@ -87,6 +94,15 @@ const Default = (): React.ReactElement => {
             autoClosingDate={posting.autoClosingDate}
             description={posting.description}
             branchName={posting.branch.name}
+            type={
+              isEventPosting(
+                new Date(posting.startDate),
+                new Date(posting.endDate),
+              )
+                ? "EVENT"
+                : "OPPORTUNITY"
+            }
+            shifts={posting.shifts}
             navigateToDetails={() => navigateToDetails(posting.id)}
             navigateToAdminSchedule={() => navigateToAdminSchedule(posting.id)}
           />

--- a/frontend/src/components/volunteer/EmptyPostingCard.tsx
+++ b/frontend/src/components/volunteer/EmptyPostingCard.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Text, Box, VStack } from "@chakra-ui/react";
+import { PostingRecurrenceType } from "../../types/PostingTypes";
 
 type EmptyPostingCardProps = {
-  type: "event" | "opportunity";
+  type: PostingRecurrenceType;
 };
 
 const EmptyPostingCard = ({
@@ -24,7 +25,7 @@ const EmptyPostingCard = ({
           color="text.gray"
         >
           There are no{" "}
-          {type === "event" ? "events" : "regular volunteer opportunities"} at
+          {type === "EVENT" ? "events" : "regular volunteer opportunities"} at
           this time. Please check back soon.
         </Text>
       </VStack>

--- a/frontend/src/types/PostingTypes.ts
+++ b/frontend/src/types/PostingTypes.ts
@@ -3,3 +3,5 @@ export type PostingType = "INDIVIDUAL" | "GROUP";
 export type PostingStatus = "DRAFT" | "PUBLISHED" | "ARCHIVED";
 
 export type RecurrenceInterval = "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "NONE";
+
+export type PostingRecurrenceType = "EVENT" | "OPPORTUNITY";

--- a/frontend/src/utils/DateTimeUtils.ts
+++ b/frontend/src/utils/DateTimeUtils.ts
@@ -8,7 +8,7 @@ import { FilterType } from "../types/DateFilterTypes";
  * @returns corresponding time string string in format hh:mm:(a/p)m
  */
 export const formatTimeHourMinutes = (date: Date): string => {
-  return moment.utc(date).format("h:mm a");
+  return moment.utc(date).format("h:mma");
 };
 
 /**
@@ -168,4 +168,17 @@ export const getMonthsInRange = (startDate: Date, endDate: Date): Date[] => {
     currentMonth = currentMonth.add(1, "month");
   }
   return monthsInRange;
+};
+
+/**
+ * Get whether or not a posting is an event based
+ * on start/end time, should be same day.
+ * @param startDate the start date of the range
+ * @param endDate the end date of the range
+ * @returns whether or not a posting is an event based on start/end time
+ */
+export const isEventPosting = (startDate: Date, endDate: Date): boolean => {
+  // NOTE: We might run into inconsistencies in timezones as we expect
+  // this logic to be for Toronto time only
+  return moment(startDate).isSame(endDate, "day");
 };


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #254


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Add new conditions for regular vs event posting cards
- Add logic to render time range for event posting based on all children 

Regular
![image](https://user-images.githubusercontent.com/44826218/177020285-469ca103-9192-46f8-9dab-6afd7ddf8ef5.png)

Event
![image](https://user-images.githubusercontent.com/44826218/177020294-f035cd57-76cb-4f90-b270-dd40783728a8.png)

NOTE: An event posting is a posting whose start/end date are the same (EDT time)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Add an event and regular posting that is visible on browse posting page
2. Go to `volunteer/postings`
3. Ensure that you can see the event card with specific date and specified time range
4. Ensure that you can see the regular posting card with date range and no specific time range on the card instead saying "See posting details"


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness and cleaniness


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR