### PR TITLE
Query skills and create languages array used for account creation page

### DIFF
--- a/frontend/src/components/user/AccountForm.tsx
+++ b/frontend/src/components/user/AccountForm.tsx
@@ -1,4 +1,5 @@
 import { Formik, Field, Form } from "formik";
+import { gql, useQuery } from "@apollo/client";
 import {
   Box,
   Button,
@@ -17,13 +18,18 @@ import {
   Tooltip,
   UnorderedList,
 } from "@chakra-ui/react";
-import React from "react";
+import React, { useState } from "react";
 import { QuestionOutlineIcon } from "@chakra-ui/icons";
 import moment from "moment";
-import { SkillResponseDTO } from "../../types/api/SkillTypes";
+
+import {
+  SkillResponseDTO,
+  SkillQueryResponse,
+} from "../../types/api/SkillTypes";
 import {
   CreateVolunteerDTO,
   CreateEmployeeDTO,
+  LANGUAGES,
 } from "../../types/api/UserType";
 
 type AccountFormProps = {
@@ -33,20 +39,14 @@ type AccountFormProps = {
   onEmployeeCreate: (employee: CreateEmployeeDTO) => void;
 };
 
-const TEST_SKILLS: SkillResponseDTO[] = [
-  {
-    id: "1",
-    name: "CPR",
-  },
-  {
-    id: "2",
-    name: "First Aid",
-  },
-  {
-    id: "3",
-    name: "Cooking",
-  },
-];
+const SKILLS = gql`
+  query BranchManagerModal_Skills {
+    skills {
+      id
+      name
+    }
+  }
+`;
 
 interface AccountFormValues {
   profilePhoto: string;
@@ -67,11 +67,19 @@ const AccountForm = ({
   onVolunteerCreate,
   onEmployeeCreate,
 }: AccountFormProps): React.ReactElement => {
-  const [agreeToTerms, setAgreeToTerms] = React.useState(false);
+  const [agreeToTerms, setAgreeToTerms] = useState(false);
+  const [skills, setSkills] = useState<SkillResponseDTO[]>([]);
 
   const toggleAgreeToTerms = (): void => {
     setAgreeToTerms(!agreeToTerms);
   };
+
+  useQuery<SkillQueryResponse>(SKILLS, {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      setSkills(data.skills);
+    },
+  });
 
   const selectSkill = (
     skill: string,
@@ -80,7 +88,7 @@ const AccountForm = ({
   ) => {
     // If the skill is not already selected, add it to the list of skills
     if (!currentSkills.some((s) => s.id === skill)) {
-      const skillName = TEST_SKILLS.find((s) => s.id === skill)?.name || "";
+      const skillName = skills.find((s) => s.id === skill)?.name || "";
       setFieldValue("skills", [
         ...currentSkills,
         {
@@ -267,7 +275,7 @@ const AccountForm = ({
                         );
                       }}
                     >
-                      {TEST_SKILLS.map((skill) => (
+                      {skills.map((skill) => (
                         <option key={skill.id} value={skill.id}>
                           {skill.name}
                         </option>

--- a/frontend/src/types/api/SkillTypes.ts
+++ b/frontend/src/types/api/SkillTypes.ts
@@ -6,3 +6,7 @@ export type SkillDTO = {
 export type SkillRequestDTO = Omit<SkillDTO, "id">;
 
 export type SkillResponseDTO = SkillDTO;
+
+export type SkillQueryResponse = {
+  skills: SkillResponseDTO[];
+};

--- a/frontend/src/types/api/UserType.ts
+++ b/frontend/src/types/api/UserType.ts
@@ -2,14 +2,18 @@ import { BranchResponseDTO } from "./BranchTypes";
 import { SkillResponseDTO } from "./SkillTypes";
 
 export type Role = "ADMIN" | "VOLUNTEER" | "EMPLOYEE";
-export type Language =
-  | "ENGLISH"
-  | "FRENCH"
-  | "ITALIAN"
-  | "CHINESE"
-  | "SPANISH"
-  | "HINDI"
-  | "RUSSIAN";
+
+export const LANGUAGES = [
+  "ENGLISH",
+  "FRENCH",
+  "ITALIAN",
+  "CHINESE",
+  "SPANISH",
+  "HINDI",
+  "RUSSIAN",
+] as const;
+type LanguageTuple = typeof LANGUAGES;
+export type Language = LanguageTuple[number];
 
 export type UserDTO = {
   id: string;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #412 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added GraphQL query for skills in `AccountForm.tsx` for account creation page
* Created `LANGUAGES` array in `UserType.ts` and `Language` string union type
  * Imported `LANGUAGES` in `AccountForm.tsx` 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `http://localhost:3000/new-account` to see the account creation page
2. Check the skills are being queried (currently no form field for languages)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
