### PR TITLE
Remove admin authorization for skills query

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -159,8 +159,6 @@ const graphQLMiddlewares = {
     employeeUserById: authorizedByAdminAndEmployee(),
     employeeUserByEmail: authorizedByAdminAndEmployee(),
     employeeUsers: authorizedByAdmin(),
-    skill: authorizedByAdmin(),
-    skills: authorizedByAdmin(),
     branch: authorizedByAdmin(),
     branches: authorizedByAdmin(),
     getShiftSignupsForUser: authorizedByAdminAndVolunteer(),


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Removed admin authorization for querying skills - this allows the `/new-account` page to display skills for all users.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to `http://localhost:3000/new-account` and check that the list of skills show up without being logged in


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Functionality


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
