### PR TITLE
Add resolver and types for delete user invite

### DIFF
--- a/backend/graphql/resolvers/userResolvers.ts
+++ b/backend/graphql/resolvers/userResolvers.ts
@@ -16,7 +16,7 @@ import {
   UpdateEmployeeUserDTO,
   CreateEmployeeUserDTO,
   Role,
-  CreateUserInviteResponse,
+  UserInviteResponse,
 } from "../../types";
 import { generateCSV } from "../../utilities/CSVUtils";
 
@@ -110,8 +110,14 @@ const userResolvers = {
     createUserInvite: async (
       _parent: undefined,
       { email, role }: { email: string; role: Role },
-    ): Promise<CreateUserInviteResponse> => {
+    ): Promise<UserInviteResponse> => {
       return userService.createUserInvite(email, role);
+    },
+    deleteUserInvite: async (
+      _parent: undefined,
+      { email }: { email: string },
+    ): Promise<UserInviteResponse> => {
+      return userService.deleteUserInvite(email);
     },
 
     // VolunteerUsers

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -85,7 +85,7 @@ const userType = gql`
     emergencyContactEmail: String
   }
 
-  type CreateUserInviteResponse {
+  type UserInviteResponse {
     pid: String!
     email: String!
     role: Role!
@@ -180,7 +180,8 @@ const userType = gql`
     updateUser(id: ID!, user: UpdateUserDTO!): UserDTO!
     deleteUserById(id: ID!): ID
     deleteUserByEmail(email: String!): ID
-    createUserInvite(email: String!, role: Role!): CreateUserInviteResponse!
+    createUserInvite(email: String!, role: Role!): UserInviteResponse!
+    deleteUserInvite(email: String!): UserInviteResponse!
     createVolunteerUser(
       volunteerUser: CreateVolunteerUserDTO!
     ): VolunteerUserResponseDTO!

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -86,7 +86,7 @@ const userType = gql`
   }
 
   type UserInviteResponse {
-    pid: String!
+    uuid: String!
     email: String!
     role: Role!
   }

--- a/backend/prisma/migrations/20220710175708_user_invite_better_field_name_unique_email/migration.sql
+++ b/backend/prisma/migrations/20220710175708_user_invite_better_field_name_unique_email/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The primary key for the `user_invites` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `pid` on the `user_invites` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[email]` on the table `user_invites` will be added. If there are existing duplicate values, this will fail.
+  - The required column `uuid` was added to the `user_invites` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+
+*/
+-- AlterTable
+ALTER TABLE "user_invites" DROP CONSTRAINT "user_invites_pkey",
+DROP COLUMN "pid",
+ADD COLUMN     "uuid" TEXT NOT NULL,
+ADD CONSTRAINT "user_invites_pkey" PRIMARY KEY ("uuid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_invites_email_key" ON "user_invites"("email");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -163,8 +163,8 @@ model Employee {
 }
 
 model UserInvite {
-  pid   String @id @default(uuid())
-  email String
+  uuid String @id @default(uuid())
+  email String @unique
   role  Role
 
   @@map("user_invites")

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -14,7 +14,7 @@ import {
   CreateEmployeeUserDTO,
   EmployeeUserResponseDTO,
   UpdateEmployeeUserDTO,
-  CreateUserInviteResponse,
+  UserInviteResponse,
   Role,
 } from "../../types";
 import logger from "../../utilities/logger";
@@ -457,7 +457,7 @@ class UserService implements IUserService {
   async createUserInvite(
     email: string,
     role: Role,
-  ): Promise<CreateUserInviteResponse> {
+  ): Promise<UserInviteResponse> {
     try {
       const userInvite = await prisma.userInvite.create({
         data: {
@@ -473,6 +473,26 @@ class UserService implements IUserService {
     } catch (error: unknown) {
       Logger.error(
         `Failed to create user invite row. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async deleteUserInvite(email: string): Promise<UserInviteResponse> {
+    try {
+      const userInvite = await prisma.userInvite.delete({
+        where: {
+          email,
+        },
+      });
+      return {
+        email: userInvite.email,
+        role: userInvite.role.toString() as Role,
+        pid: userInvite.pid,
+      };
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete user invite row. Reason = ${getErrorMessage(error)}`,
       );
       throw error;
     }

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -468,7 +468,7 @@ class UserService implements IUserService {
       return {
         email: userInvite.email,
         role: userInvite.role.toString() as Role,
-        pid: userInvite.pid,
+        uuid: userInvite.uuid,
       };
     } catch (error: unknown) {
       Logger.error(
@@ -488,7 +488,7 @@ class UserService implements IUserService {
       return {
         email: userInvite.email,
         role: userInvite.role.toString() as Role,
-        pid: userInvite.pid,
+        uuid: userInvite.uuid,
       };
     } catch (error: unknown) {
       Logger.error(

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -9,7 +9,7 @@ import {
   CreateEmployeeUserDTO,
   EmployeeUserResponseDTO,
   UpdateEmployeeUserDTO,
-  CreateUserInviteResponse,
+  UserInviteResponse,
 } from "../../types";
 
 interface IUserService {
@@ -100,10 +100,14 @@ interface IUserService {
    * @param role role that the user will have
    * @throws Error if invite creation fails
    */
-  createUserInvite(
-    email: string,
-    role: Role,
-  ): Promise<CreateUserInviteResponse>;
+  createUserInvite(email: string, role: Role): Promise<UserInviteResponse>;
+
+  /**
+   * Delete user invite link based on invitee email
+   * @param email user's email
+   * @throws Error if invite deletion fails
+   */
+  deleteUserInvite(email: string): Promise<UserInviteResponse>;
 
   /**
    * Get VolunteerUser associated with id

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -13,7 +13,7 @@ export type Token = {
   refreshToken: string;
 };
 
-export type CreateUserInviteResponse = {
+export type UserInviteResponse = {
   email: string;
   role: Role;
   pid: string;

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -16,7 +16,7 @@ export type Token = {
 export type UserInviteResponse = {
   email: string;
   role: Role;
-  pid: string;
+  uuid: string;
 };
 
 export type UserDTO = {


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #439 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created resolver that handles deletion of userInvite row based on unique email (follow up migration)
* Added necessary type for resolver

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create an existing user invite shown here: https://github.com/uwblueprint/sistering/pull/470
2. delete the user invite record using the invitee's email
```
 mutation {
   createUserInvite(email: "test4@gmail.com", role: VOLUNTEER) {
     uuid
   }
 }

mutation {
  deleteUserInvite(email:"test4@gmail.com") {
    uuid
  }
}
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* correctness and cleanniness


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
