### PR TITLE
Add email template utils

### DIFF
--- a/backend/constants/emailTemplates.ts
+++ b/backend/constants/emailTemplates.ts
@@ -1,0 +1,239 @@
+export const FONT_LINKS = `
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@500&family=Raleway:wght@600&family=Work+Sans:wght@700&display=swap"
+    rel="stylesheet"
+  />
+`;
+
+export const ACCOUNT_CREATION_INVITE_STYLE = `
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      font-size: 14px;
+    }
+    .email {
+      background: rgba(255, 255, 255, 1);
+      opacity: 1;
+      overflow: hidden;
+    }
+    .logo {
+      width: 150px;
+      height: 27px;
+      background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-size: cover;
+      opacity: 1;
+      margin-top: 57px;
+      margin-left: 70px;
+      overflow: hidden;
+    }
+    .title {
+      color: rgba(112, 0, 222, 1);
+      padding-left: 70px;
+      padding-top: 50px;
+      font-family: work sans;
+      font-weight: 700;
+      font-size: 24px;
+      opacity: 1;
+      text-align: left;
+    }
+    .text {
+      width: 600px;
+      color: rgba(0, 0, 0, 1);
+      padding-left: 70px;
+      padding-top: 37px;
+      font-family: inter;
+      font-weight: medium;
+      font-size: 18px;
+      opacity: 1;
+      text-align: left;
+    }
+    .btn {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      padding: 0.5em 1em;
+      background: #7000de;
+      border-radius: 6px;
+      width: 13em;
+      height: 3em;
+      flex: none;
+      margin-left: 70px;
+      margin-top: 37px;
+      appearance: button;
+      text-decoration: none;
+      color: initial;
+    }
+    .btn-text {
+      font-family: raleway;
+      font-style: normal;
+      font-weight: 600;
+      font-size: 1.3em;
+      display: flex;
+      align-items: center;
+      color: #ffffff;
+      flex: none;
+      order: 1;
+      flex-grow: 0;
+    }
+  </style>
+`;
+
+export const PASSWORD_RESET_STYLE = `
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      font-size: 14px;
+    }
+    .email {
+      background: rgba(255, 255, 255, 1);
+      opacity: 1;
+      overflow: hidden;
+    }
+    .logo {
+      width: 150px;
+      height: 27px;
+      background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-size: cover;
+      opacity: 1;
+      margin-top: 57px;
+      margin-left: 70px;
+      overflow: hidden;
+    }
+    .title {
+      color: rgba(112, 0, 222, 1);
+      padding-left: 70px;
+      padding-top: 45px;
+      font-family: work sans;
+      font-weight: 700;
+      font-size: 24px;
+      opacity: 1;
+      text-align: left;
+    }
+    .text {
+      width: 493px;
+      color: rgba(0, 0, 0, 1);
+      padding-left: 70px;
+      padding-top: 42px;
+      font-family: inter;
+      font-weight: medium;
+      font-size: 18px;
+      opacity: 1;
+      text-align: left;
+    }
+    .btn {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      padding: 0.5em 1em;
+      background: #7000de;
+      border-radius: 6px;
+      width: 12em;
+      height: 3em;
+      flex: none;
+      margin-left: 70px;
+      margin-top: 21px;
+      appearance: button;
+      text-decoration: none;
+      color: initial;
+    }
+    .btn-text {
+      font-family: raleway;
+      font-style: normal;
+      font-weight: 600;
+      font-size: 1.3em;
+      display: flex;
+      align-items: center;
+      color: #ffffff;
+      flex: none;
+      order: 1;
+      flex-grow: 0;
+    }
+  </style>
+`;
+
+export const ACCOUNT_CREATION_INVITE_REMINDER_STYLE = `
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      font-size: 14px;
+    }
+    .email {
+      background: rgba(255, 255, 255, 1);
+      opacity: 1;
+      overflow: hidden;
+    }
+    .logo {
+      width: 150px;
+      height: 27px;
+      background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-size: cover;
+      opacity: 1;
+      margin-top: 57px;
+      margin-left: 70px;
+      overflow: hidden;
+    }
+    .title {
+      color: rgba(112, 0, 222, 1);
+      padding-left: 70px;
+      padding-top: 45px;
+      font-family: work sans;
+      font-weight: 700;
+      font-size: 24px;
+      opacity: 1;
+      text-align: left;
+    }
+    .text {
+      width: 600px;
+      color: rgba(0, 0, 0, 1);
+      padding-left: 70px;
+      padding-top: 42px;
+      font-family: inter;
+      font-weight: medium;
+      font-size: 18px;
+      opacity: 1;
+      text-align: left;
+    }
+    .btn {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      padding: 0.5em 1em;
+      background: #7000de;
+      border-radius: 6px;
+      width: 13em;
+      height: 3em;
+      flex: none;
+      margin-left: 70px;
+      margin-top: 45px;
+      appearance: button;
+      text-decoration: none;
+      color: initial;
+    }
+    .btn-text {
+      font-family: raleway;
+      font-style: normal;
+      font-weight: 600;
+      font-size: 1.3em;
+      display: flex;
+      align-items: center;
+      color: #ffffff;
+      flex: none;
+      order: 1;
+      flex-grow: 0;
+    }
+  </style>
+`;

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -7,6 +7,7 @@ import { AuthDTO, Role, Token } from "../../types";
 import FirebaseRestClient from "../../utilities/firebaseRestClient";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
+import { passwordResetTemplate } from "../../utilities/templateUtils";
 
 const Logger = logger(__filename);
 
@@ -77,15 +78,7 @@ class AuthService implements IAuthService {
       const resetLink = await firebaseAdmin
         .auth()
         .generatePasswordResetLink(email);
-      const emailBody = `
-      Hello,
-      <br><br>
-      We have received a password reset request for your account.
-      Please click the following link to reset it.
-      <strong>This link is only valid for 1 hour.</strong>
-      <br><br>
-      <a href=${resetLink}>Reset Password</a>`;
-
+      const emailBody = passwordResetTemplate(resetLink);
       this.emailService.sendEmail(email, "Your Password Reset Link", emailBody);
     } catch (error: unknown) {
       Logger.error(

--- a/backend/utilities/templateUtils.ts
+++ b/backend/utilities/templateUtils.ts
@@ -1,3 +1,10 @@
+import {
+  ACCOUNT_CREATION_INVITE_REMINDER_STYLE,
+  ACCOUNT_CREATION_INVITE_STYLE,
+  FONT_LINKS,
+  PASSWORD_RESET_STYLE,
+} from "../constants/emailTemplates";
+
 export const accountCreationInviteTemplate = (
   role: string,
   inviteLink: string,
@@ -5,86 +12,8 @@ export const accountCreationInviteTemplate = (
   return `
   <html>
     <head>
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-      <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@500&family=Raleway:wght@600&family=Work+Sans:wght@700&display=swap"
-        rel="stylesheet"
-      />
-      <style>
-        * {
-          box-sizing: border-box;
-        }
-        body {
-          font-size: 14px;
-        }
-        .email {
-          background: rgba(255, 255, 255, 1);
-          opacity: 1;
-          overflow: hidden;
-        }
-        .logo {
-          width: 150px;
-          height: 27px;
-          background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
-          background-repeat: no-repeat;
-          background-position: center center;
-          background-size: cover;
-          opacity: 1;
-          margin-top: 57px;
-          margin-left: 70px;
-          overflow: hidden;
-        }
-        .title {
-          color: rgba(112, 0, 222, 1);
-          padding-left: 70px;
-          padding-top: 50px;
-          font-family: work sans;
-          font-weight: 700;
-          font-size: 24px;
-          opacity: 1;
-          text-align: left;
-        }
-        .text {
-          width: 600px;
-          color: rgba(0, 0, 0, 1);
-          padding-left: 70px;
-          padding-top: 37px;
-          font-family: inter;
-          font-weight: medium;
-          font-size: 18px;
-          opacity: 1;
-          text-align: left;
-        }
-        .btn {
-          display: flex;
-          flex-direction: row;
-          align-items: center;
-          padding: 0.5em 1em;
-          background: #7000de;
-          border-radius: 6px;
-          width: 13em;
-          height: 3em;
-          flex: none;
-          margin-left: 70px;
-          margin-top: 37px;
-          appearance: button;
-          text-decoration: none;
-          color: initial;
-        }
-        .btn-text {
-          font-family: raleway;
-          font-style: normal;
-          font-weight: 600;
-          font-size: 1.3em;
-          display: flex;
-          align-items: center;
-          color: #ffffff;
-          flex: none;
-          order: 1;
-          flex-grow: 0;
-        }
-      </style>
+      ${FONT_LINKS}
+      ${ACCOUNT_CREATION_INVITE_STYLE}
     </head>
     <body>
       <div class="email">
@@ -122,86 +51,8 @@ export const accountCreationInviteReminderTemplate = (
   return `
   <html>
     <head>
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-      <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@500&family=Raleway:wght@600&family=Work+Sans:wght@700&display=swap"
-        rel="stylesheet"
-      />
-      <style>
-        * {
-          box-sizing: border-box;
-        }
-        body {
-          font-size: 14px;
-        }
-        .email {
-          background: rgba(255, 255, 255, 1);
-          opacity: 1;
-          overflow: hidden;
-        }
-        .logo {
-          width: 150px;
-          height: 27px;
-          background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
-          background-repeat: no-repeat;
-          background-position: center center;
-          background-size: cover;
-          opacity: 1;
-          margin-top: 57px;
-          margin-left: 70px;
-          overflow: hidden;
-        }
-        .title {
-          color: rgba(112, 0, 222, 1);
-          padding-left: 70px;
-          padding-top: 45px;
-          font-family: work sans;
-          font-weight: 700;
-          font-size: 24px;
-          opacity: 1;
-          text-align: left;
-        }
-        .text {
-          width: 600px;
-          color: rgba(0, 0, 0, 1);
-          padding-left: 70px;
-          padding-top: 42px;
-          font-family: inter;
-          font-weight: medium;
-          font-size: 18px;
-          opacity: 1;
-          text-align: left;
-        }
-        .btn {
-          display: flex;
-          flex-direction: row;
-          align-items: center;
-          padding: 0.5em 1em;
-          background: #7000de;
-          border-radius: 6px;
-          width: 13em;
-          height: 3em;
-          flex: none;
-          margin-left: 70px;
-          margin-top: 45px;
-          appearance: button;
-          text-decoration: none;
-          color: initial;
-        }
-        .btn-text {
-          font-family: raleway;
-          font-style: normal;
-          font-weight: 600;
-          font-size: 1.3em;
-          display: flex;
-          align-items: center;
-          color: #ffffff;
-          flex: none;
-          order: 1;
-          flex-grow: 0;
-        }
-      </style>
+      ${FONT_LINKS}
+      ${ACCOUNT_CREATION_INVITE_REMINDER_STYLE}
     </head>
     <body>
       <div class="email">
@@ -236,86 +87,8 @@ export const passwordResetTemplate = (resetLink: string): string => {
   return `
   <html>
     <head>
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-      <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@500&family=Raleway:wght@600&family=Work+Sans:wght@700&display=swap"
-        rel="stylesheet"
-      />
-      <style>
-        * {
-          box-sizing: border-box;
-        }
-        body {
-          font-size: 14px;
-        }
-        .email {
-          background: rgba(255, 255, 255, 1);
-          opacity: 1;
-          overflow: hidden;
-        }
-        .logo {
-          width: 150px;
-          height: 27px;
-          background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
-          background-repeat: no-repeat;
-          background-position: center center;
-          background-size: cover;
-          opacity: 1;
-          margin-top: 57px;
-          margin-left: 70px;
-          overflow: hidden;
-        }
-        .title {
-          color: rgba(112, 0, 222, 1);
-          padding-left: 70px;
-          padding-top: 45px;
-          font-family: work sans;
-          font-weight: 700;
-          font-size: 24px;
-          opacity: 1;
-          text-align: left;
-        }
-        .text {
-          width: 493px;
-          color: rgba(0, 0, 0, 1);
-          padding-left: 70px;
-          padding-top: 42px;
-          font-family: inter;
-          font-weight: medium;
-          font-size: 18px;
-          opacity: 1;
-          text-align: left;
-        }
-        .btn {
-          display: flex;
-          flex-direction: row;
-          align-items: center;
-          padding: 0.5em 1em;
-          background: #7000de;
-          border-radius: 6px;
-          width: 12em;
-          height: 3em;
-          flex: none;
-          margin-left: 70px;
-          margin-top: 21px;
-          appearance: button;
-          text-decoration: none;
-          color: initial;
-        }
-        .btn-text {
-          font-family: raleway;
-          font-style: normal;
-          font-weight: 600;
-          font-size: 1.3em;
-          display: flex;
-          align-items: center;
-          color: #ffffff;
-          flex: none;
-          order: 1;
-          flex-grow: 0;
-        }
-      </style>
+      ${FONT_LINKS}
+      ${PASSWORD_RESET_STYLE}
     </head>
     <body>
       <div class="email">

--- a/backend/utilities/templateUtils.ts
+++ b/backend/utilities/templateUtils.ts
@@ -1,0 +1,336 @@
+export const accountCreationInviteTemplate = (
+  role: string,
+  inviteLink: string,
+): string => {
+  return `
+  <html>
+    <head>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@500&family=Raleway:wght@600&family=Work+Sans:wght@700&display=swap"
+        rel="stylesheet"
+      />
+      <style>
+        * {
+          box-sizing: border-box;
+        }
+        body {
+          font-size: 14px;
+        }
+        .email {
+          background: rgba(255, 255, 255, 1);
+          opacity: 1;
+          overflow: hidden;
+        }
+        .logo {
+          width: 150px;
+          height: 27px;
+          background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
+          background-repeat: no-repeat;
+          background-position: center center;
+          background-size: cover;
+          opacity: 1;
+          margin-top: 57px;
+          margin-left: 70px;
+          overflow: hidden;
+        }
+        .title {
+          color: rgba(112, 0, 222, 1);
+          padding-left: 70px;
+          padding-top: 50px;
+          font-family: work sans;
+          font-weight: 700;
+          font-size: 24px;
+          opacity: 1;
+          text-align: left;
+        }
+        .text {
+          width: 600px;
+          color: rgba(0, 0, 0, 1);
+          padding-left: 70px;
+          padding-top: 37px;
+          font-family: inter;
+          font-weight: medium;
+          font-size: 18px;
+          opacity: 1;
+          text-align: left;
+        }
+        .btn {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          padding: 0.5em 1em;
+          background: #7000de;
+          border-radius: 6px;
+          width: 13em;
+          height: 3em;
+          flex: none;
+          margin-left: 70px;
+          margin-top: 37px;
+          appearance: button;
+          text-decoration: none;
+          color: initial;
+        }
+        .btn-text {
+          font-family: raleway;
+          font-style: normal;
+          font-weight: 600;
+          font-size: 1.3em;
+          display: flex;
+          align-items: center;
+          color: #ffffff;
+          flex: none;
+          order: 1;
+          flex-grow: 0;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="email">
+        <div class="logo"></div>
+        <div class="title">Welcome to your ${role} account!</div>
+        <div class="text">
+          Click the button below to access your account. This link will expire in
+          2 weeks.
+        </div>
+        <a class="btn" href="${inviteLink}" target="_blank">
+          <span class="btn-text">Setup my account</span>
+        </a>
+      </div>
+    </body>
+  </html>
+  `;
+};
+
+export const adminAccountCreationInviteTemplate = (
+  inviteLink: string,
+): string => {
+  return accountCreationInviteTemplate("Administrator", inviteLink);
+};
+
+export const volunteerAccountCreationInviteTemplate = (
+  inviteLink: string,
+): string => {
+  return accountCreationInviteTemplate("Volunteer", inviteLink);
+};
+
+export const accountCreationInviteReminderTemplate = (
+  role: string,
+  inviteLink: string,
+): string => {
+  return `
+  <html>
+    <head>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@500&family=Raleway:wght@600&family=Work+Sans:wght@700&display=swap"
+        rel="stylesheet"
+      />
+      <style>
+        * {
+          box-sizing: border-box;
+        }
+        body {
+          font-size: 14px;
+        }
+        .email {
+          background: rgba(255, 255, 255, 1);
+          opacity: 1;
+          overflow: hidden;
+        }
+        .logo {
+          width: 150px;
+          height: 27px;
+          background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
+          background-repeat: no-repeat;
+          background-position: center center;
+          background-size: cover;
+          opacity: 1;
+          margin-top: 57px;
+          margin-left: 70px;
+          overflow: hidden;
+        }
+        .title {
+          color: rgba(112, 0, 222, 1);
+          padding-left: 70px;
+          padding-top: 45px;
+          font-family: work sans;
+          font-weight: 700;
+          font-size: 24px;
+          opacity: 1;
+          text-align: left;
+        }
+        .text {
+          width: 600px;
+          color: rgba(0, 0, 0, 1);
+          padding-left: 70px;
+          padding-top: 42px;
+          font-family: inter;
+          font-weight: medium;
+          font-size: 18px;
+          opacity: 1;
+          text-align: left;
+        }
+        .btn {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          padding: 0.5em 1em;
+          background: #7000de;
+          border-radius: 6px;
+          width: 13em;
+          height: 3em;
+          flex: none;
+          margin-left: 70px;
+          margin-top: 45px;
+          appearance: button;
+          text-decoration: none;
+          color: initial;
+        }
+        .btn-text {
+          font-family: raleway;
+          font-style: normal;
+          font-weight: 600;
+          font-size: 1.3em;
+          display: flex;
+          align-items: center;
+          color: #ffffff;
+          flex: none;
+          order: 1;
+          flex-grow: 0;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="email">
+        <div class="logo"></div>
+        <div class="title">Hi! Your invitation link will be expiring soon</div>
+        <div class="text">
+          Click the button below to access your ${role} account. This link will
+          expire in a week.
+        </div>
+        <a class="btn" href="${inviteLink}" target="_blank">
+          <span class="btn-text">Setup my account</span>
+        </a>
+      </div>
+    </body>
+  </html>
+  `;
+};
+
+export const adminAccountCreationInviteReminderTemplate = (
+  inviteLink: string,
+): string => {
+  return accountCreationInviteTemplate("administrator", inviteLink);
+};
+
+export const volunteerAccountCreationInviteReminderTemplate = (
+  inviteLink: string,
+): string => {
+  return accountCreationInviteTemplate("volunteer", inviteLink);
+};
+
+export const passwordResetTemplate = (resetLink: string): string => {
+  return `
+  <html>
+    <head>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@500&family=Raleway:wght@600&family=Work+Sans:wght@700&display=swap"
+        rel="stylesheet"
+      />
+      <style>
+        * {
+          box-sizing: border-box;
+        }
+        body {
+          font-size: 14px;
+        }
+        .email {
+          background: rgba(255, 255, 255, 1);
+          opacity: 1;
+          overflow: hidden;
+        }
+        .logo {
+          width: 150px;
+          height: 27px;
+          background: url("https://firebasestorage.googleapis.com/v0/b/sistering-dev.appspot.com/o/sistering-logo.png?alt=media&token=58c68ee3-848b-4fcc-902c-77f3dbf252b6");
+          background-repeat: no-repeat;
+          background-position: center center;
+          background-size: cover;
+          opacity: 1;
+          margin-top: 57px;
+          margin-left: 70px;
+          overflow: hidden;
+        }
+        .title {
+          color: rgba(112, 0, 222, 1);
+          padding-left: 70px;
+          padding-top: 45px;
+          font-family: work sans;
+          font-weight: 700;
+          font-size: 24px;
+          opacity: 1;
+          text-align: left;
+        }
+        .text {
+          width: 493px;
+          color: rgba(0, 0, 0, 1);
+          padding-left: 70px;
+          padding-top: 42px;
+          font-family: inter;
+          font-weight: medium;
+          font-size: 18px;
+          opacity: 1;
+          text-align: left;
+        }
+        .btn {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          padding: 0.5em 1em;
+          background: #7000de;
+          border-radius: 6px;
+          width: 12em;
+          height: 3em;
+          flex: none;
+          margin-left: 70px;
+          margin-top: 21px;
+          appearance: button;
+          text-decoration: none;
+          color: initial;
+        }
+        .btn-text {
+          font-family: raleway;
+          font-style: normal;
+          font-weight: 600;
+          font-size: 1.3em;
+          display: flex;
+          align-items: center;
+          color: #ffffff;
+          flex: none;
+          order: 1;
+          flex-grow: 0;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="email">
+        <div class="logo"></div>
+        <div class="title">Hello, you requested a password reset</div>
+        <div class="text">
+          A password reset request was recieved from your account. Please click
+          the button below to reset it. This link will expire in
+          <strong>1 hour</strong>.
+        </div>
+        <a class="btn" href="${resetLink}" target="_blank">
+          <span class="btn-text">Reset Password</span>
+        </a>
+      </div>
+    </body>
+  </html>
+  `;
+};


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #483

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add templates
* Use it for reset-password email as an example
 
![image](https://user-images.githubusercontent.com/44826218/178861741-96587fb6-fc49-4f40-a8f0-95e7ff382eb3.png)

![image](https://user-images.githubusercontent.com/44826218/178861758-fa418da2-4090-4d71-8af4-c4a6a4e04777.png)

![image](https://user-images.githubusercontent.com/44826218/178861786-a6a2ee3d-fa9c-43ba-8d91-9718e46431bd.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run this app locally since backend changes is not in preview
2. Click reset password and ensure the email as designed

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Look and feel
* Code cleanliness

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR