### PR TITLE
Create Volunteer Profile Side Panel

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -59,7 +59,12 @@ const volunteerUsers = [
       hireDate: new Date(),
       dateOfBirth: new Date("August 19, 2000 23:15:30"),
       branches: [{ name: Branches.Arts }],
-      skills: [{ name: Skills.Cooking }, { name: Skills.CPR }, { name: Skills.Dancing }, { name: Skills.Yoga }],
+      skills: [
+        { name: Skills.Cooking },
+        { name: Skills.CPR },
+        { name: Skills.Dancing },
+        { name: Skills.Yoga },
+      ],
     },
   },
   {
@@ -72,7 +77,7 @@ const volunteerUsers = [
       hireDate: addDays(new Date(), -7),
       dateOfBirth: new Date("August 19, 2000 23:15:30"),
       branches: [{ name: Branches.Kitchen }],
-      skills: [{ name: Skills.Dancing }],
+      skills: [],
     },
   },
 ];
@@ -263,7 +268,7 @@ const main = async () => {
             create: {
               ...user.volunteer,
               branches: { connect: user.volunteer.branches },
-              skills: { connect: user.volunteer.skills }
+              skills: { connect: user.volunteer.skills },
             },
           },
         },

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -59,6 +59,7 @@ const volunteerUsers = [
       hireDate: new Date(),
       dateOfBirth: new Date("August 19, 2000 23:15:30"),
       branches: [{ name: Branches.Arts }],
+      skills: [{ name: Skills.Cooking }, { name: Skills.CPR }, { name: Skills.Dancing }, { name: Skills.Yoga }],
     },
   },
   {
@@ -71,6 +72,7 @@ const volunteerUsers = [
       hireDate: addDays(new Date(), -7),
       dateOfBirth: new Date("August 19, 2000 23:15:30"),
       branches: [{ name: Branches.Kitchen }],
+      skills: [{ name: Skills.Dancing }],
     },
   },
 ];
@@ -261,6 +263,7 @@ const main = async () => {
             create: {
               ...user.volunteer,
               branches: { connect: user.volunteer.branches },
+              skills: { connect: user.volunteer.skills }
             },
           },
         },

--- a/frontend/src/components/admin/schedule/AdminScheduleVolunteerRow.tsx
+++ b/frontend/src/components/admin/schedule/AdminScheduleVolunteerRow.tsx
@@ -18,6 +18,10 @@ type AdminScheduleVolunteerRowProps = {
   isDisabled: boolean;
   onSignupCheckboxClick: (id: string, isChecked: boolean) => void;
   isReadOnly: boolean;
+  onVolunteerProfileClick: (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => void;
 };
 
 const AdminScheduleVolunteerRow: React.FC<AdminScheduleVolunteerRowProps> = ({
@@ -28,6 +32,7 @@ const AdminScheduleVolunteerRow: React.FC<AdminScheduleVolunteerRowProps> = ({
   isDisabled,
   onSignupCheckboxClick,
   isReadOnly,
+  onVolunteerProfileClick,
 }: AdminScheduleVolunteerRowProps): React.ReactElement => {
   return (
     <Box
@@ -62,9 +67,9 @@ const AdminScheduleVolunteerRow: React.FC<AdminScheduleVolunteerRowProps> = ({
             colorScheme="none"
             aria-label="Person Icon"
             icon={<Image src={PersonIcon} alt="Person Icon" h={4} />}
-            // onClick to be changed later to open a panel that displays the volunteer's info
-            // eslint-disable-next-line no-console
-            onClick={() => console.log(volunteerID)}
+            onClick={() => {
+              onVolunteerProfileClick(true, volunteerID);
+            }}
           />
         </HStack>
         {note === "" ? null : (

--- a/frontend/src/components/admin/schedule/AdminScheduleVolunteerTable.tsx
+++ b/frontend/src/components/admin/schedule/AdminScheduleVolunteerTable.tsx
@@ -96,12 +96,10 @@ const AdminScheduleVolunteerTable = ({
         </Flex>
       </VStack>
       <VStack w="full" spacing={0} overflow="auto">
-
-
         {signupsToDisplay.map((signup, i) => {
           const isSignupConfirmed =
             signup.status === "CONFIRMED" || signup.status === "PUBLISHED";
-          
+
           return isReadOnly && !isSignupConfirmed ? undefined : (
             <AdminScheduleVolunteerRow
               key={i}

--- a/frontend/src/components/admin/schedule/AdminScheduleVolunteerTable.tsx
+++ b/frontend/src/components/admin/schedule/AdminScheduleVolunteerTable.tsx
@@ -14,6 +14,10 @@ type AdminScheduleVolunteerTableProps = {
   onEditSaveClick: () => void;
   submitSignupsLoading: boolean;
   isReadOnly: boolean;
+  onVolunteerProfileClick: (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => void;
 };
 
 const AdminScheduleVolunteerTable = ({
@@ -25,6 +29,7 @@ const AdminScheduleVolunteerTable = ({
   onEditSaveClick,
   submitSignupsLoading,
   isReadOnly,
+  onVolunteerProfileClick,
 }: AdminScheduleVolunteerTableProps): React.ReactElement => {
   const [signupsToDisplay, setSignupsToDisplay] = useState<
     AdminSchedulingSignupsAndVolunteerResponseDTO[]
@@ -91,10 +96,12 @@ const AdminScheduleVolunteerTable = ({
         </Flex>
       </VStack>
       <VStack w="full" spacing={0} overflow="auto">
+
+
         {signupsToDisplay.map((signup, i) => {
           const isSignupConfirmed =
             signup.status === "CONFIRMED" || signup.status === "PUBLISHED";
-
+          
           return isReadOnly && !isSignupConfirmed ? undefined : (
             <AdminScheduleVolunteerRow
               key={i}
@@ -105,6 +112,7 @@ const AdminScheduleVolunteerTable = ({
               isDisabled={!isEditing}
               onSignupCheckboxClick={onSignupCheckboxClick}
               isReadOnly={isReadOnly}
+              onVolunteerProfileClick={onVolunteerProfileClick}
             />
           );
         })}

--- a/frontend/src/components/admin/schedule/ScheduleSidePanel.tsx
+++ b/frontend/src/components/admin/schedule/ScheduleSidePanel.tsx
@@ -22,6 +22,10 @@ type ScheduleSidePanelProps = {
     React.SetStateAction<AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO>
   >;
   isReadOnly: boolean;
+  onVolunteerProfileClick: (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => void;
 };
 
 const ScheduleSidePanel: React.FC<ScheduleSidePanelProps> = ({
@@ -35,6 +39,7 @@ const ScheduleSidePanel: React.FC<ScheduleSidePanelProps> = ({
   selectedShift,
   setSelectedShift,
   isReadOnly,
+  onVolunteerProfileClick,
 }: ScheduleSidePanelProps): React.ReactElement => {
   const [isEditing, setIsEditing] = useBoolean(false);
 
@@ -94,6 +99,7 @@ const ScheduleSidePanel: React.FC<ScheduleSidePanelProps> = ({
             onEditSaveClick={handleEditSaveButtonClick}
             submitSignupsLoading={submitSignupsLoading}
             isReadOnly={isReadOnly}
+            onVolunteerProfileClick={onVolunteerProfileClick}
           />
         </>
       ) : (

--- a/frontend/src/components/admin/schedule/volunteersidepanel/NoVolunteerShiftsRow.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/NoVolunteerShiftsRow.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Box, Text } from "@chakra-ui/react";
+
+type NoVolunteerShiftsRowProps = {
+  firstName: string;
+  status: string;
+};
+
+const NoVolunteerShiftsRow: React.FC<NoVolunteerShiftsRowProps> = ({
+  firstName,
+  status,
+}: NoVolunteerShiftsRowProps): React.ReactElement => {
+  return (
+    <Box
+      w="full"
+      pl="32px"
+      pr="20px"
+      pb="12px"
+      pt="12px"
+      bg="white"
+      borderBottom="1px"
+      borderColor="background.dark"
+    >
+      <Text textStyle="body-regular" fontSize="14px">
+        {firstName} has no {status} shifts right now.
+      </Text>
+    </Box>
+  );
+};
+
+export default NoVolunteerShiftsRow;

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerNameHeader.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerNameHeader.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Box, Text } from "@chakra-ui/react";
+import { ChevronLeftIcon } from "@chakra-ui/icons";
+
+type VolunteerNameHeaderProps = {
+  profileLoading: boolean;
+  firstName: string;
+  lastName: string;
+  onVolunteerProfileClick: (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => void;
+};
+
+const VolunteerNameHeader: React.FC<VolunteerNameHeaderProps> = ({
+  profileLoading,
+  firstName,
+  lastName,
+  onVolunteerProfileClick,
+}: VolunteerNameHeaderProps): React.ReactElement => {
+  return (
+    <Box
+      w="full"
+      px="32px"
+      py="17px"
+      borderLeft="1px"
+      borderBottom="1px"
+      borderColor="background.dark"
+    >
+      <Box position="relative">
+        <ChevronLeftIcon
+          position="absolute"
+          mr={2}
+          w={6}
+          h={6}
+          color="violet"
+          cursor="pointer"
+          onClick={() => onVolunteerProfileClick(false, "")}
+        />
+      </Box>
+      <Text textStyle="heading" ml={8}>
+        {profileLoading ? "Loading..." : `${firstName} ${lastName}`}
+      </Text>
+    </Box>
+  );
+};
+
+export default VolunteerNameHeader;

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsRow.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsRow.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Box, Text } from "@chakra-ui/react";
+import {
+  formatDateStringYearAbbrWeekday,
+  formatTimeHourMinutes,
+  getUTCDateForDateTimeString,
+} from "../../../../utils/DateTimeUtils";
+
+type VolunteerShiftsRowProps = {
+  postingTitle: string;
+  shiftStartTime: string;
+  shiftEndTime: string;
+  note: string;
+};
+
+const VolunteerShiftsRow: React.FC<VolunteerShiftsRowProps> = ({
+  postingTitle,
+  shiftStartTime,
+  shiftEndTime,
+  note,
+}: VolunteerShiftsRowProps): React.ReactElement => {
+  return (
+    <Box
+      w="full"
+      pl="32px"
+      pr="20px"
+      pb="12px"
+      pt="12px"
+      bg="white"
+      borderBottom="1px"
+      borderColor="background.dark"
+    >
+      <Text textStyle="body-regular" fontSize="14px" fontWeight="600">
+        {postingTitle}
+      </Text>
+
+      <Text textStyle="body-regular" fontSize="14px">
+        {formatDateStringYearAbbrWeekday(shiftStartTime)} |{" "}
+        {formatTimeHourMinutes(getUTCDateForDateTimeString(shiftStartTime))} -{" "}
+        {formatTimeHourMinutes(getUTCDateForDateTimeString(shiftEndTime))}
+      </Text>
+
+      {note ? (
+        <Text textStyle="body-regular" fontSize="14px" color="text.gray">
+          Note: &quot;{note}&quot;
+        </Text>
+      ) : null}
+    </Box>
+  );
+};
+
+export default VolunteerShiftsRow;

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsTable.tsx
@@ -32,7 +32,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
         borderBottom="1px"
         borderColor="background.dark"
       >
-        <Text textStyle="body-bold">Requested Shifts</Text>=
+        <Text textStyle="body-bold">Requested Shifts</Text>
       </VStack>
 
       <VStack w="full" spacing={0} overflow="auto">

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Text, VStack } from "@chakra-ui/react";
 import { ShiftSignupPostingResponseDTO } from "../../../../types/api/ShiftSignupTypes";
 import VolunteerShiftsRow from "./VolunteerShiftsRow";
@@ -13,6 +13,30 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
   firstName,
   shifts,
 }: VolunteerShiftsTableProps): React.ReactElement => {
+  const [filteredRequestedShifts, setFilteredRequestedShifts] = useState<
+    ShiftSignupPostingResponseDTO[]
+  >([]);
+  useEffect(() => {
+    setFilteredRequestedShifts(
+      shifts?.filter((shift) => shift.status === "PENDING"),
+    );
+    return () => {
+      setFilteredRequestedShifts([]);
+    };
+  }, [shifts]);
+
+  const [filteredScheduledShifts, setFilteredScheduledShifts] = useState<
+    ShiftSignupPostingResponseDTO[]
+  >([]);
+  useEffect(() => {
+    setFilteredScheduledShifts(
+      shifts?.filter((shift) => shift.status === "CONFIRMED"),
+    );
+    return () => {
+      setFilteredScheduledShifts([]);
+    };
+  }, [shifts]);
+
   return (
     <VStack
       w="full"
@@ -36,20 +60,18 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       </VStack>
 
       <VStack w="full" spacing={0} overflow="auto">
-        {shifts?.filter((shift) => shift.status === "PENDING").length > 0 ? (
-          shifts
-            ?.filter((shift) => shift.status === "PENDING")
-            .map((shift, i) => {
-              return (
-                <VolunteerShiftsRow
-                  key={i}
-                  postingTitle={shift.postingTitle}
-                  shiftStartTime={shift.shiftStartTime}
-                  shiftEndTime={shift.shiftEndTime}
-                  note={shift.note}
-                />
-              );
-            })
+        {filteredRequestedShifts.length > 0 ? (
+          filteredRequestedShifts.map((shift, i) => {
+            return (
+              <VolunteerShiftsRow
+                key={i}
+                postingTitle={shift.postingTitle}
+                shiftStartTime={shift.shiftStartTime}
+                shiftEndTime={shift.shiftEndTime}
+                note={shift.note}
+              />
+            );
+          })
         ) : (
           <NoVolunteerShiftsRow firstName={firstName} status="requested" />
         )}
@@ -69,20 +91,18 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       </VStack>
 
       <VStack w="full" spacing={0} overflow="auto">
-        {shifts?.filter((shift) => shift.status === "CONFIRMED").length > 0 ? (
-          shifts
-            ?.filter((shift) => shift.status === "CONFIRMED")
-            .map((shift, i) => {
-              return (
-                <VolunteerShiftsRow
-                  key={i}
-                  postingTitle={shift.postingTitle}
-                  shiftStartTime={shift.shiftStartTime}
-                  shiftEndTime={shift.shiftEndTime}
-                  note={shift.note}
-                />
-              );
-            })
+        {filteredScheduledShifts.length > 0 ? (
+          filteredScheduledShifts.map((shift, i) => {
+            return (
+              <VolunteerShiftsRow
+                key={i}
+                postingTitle={shift.postingTitle}
+                shiftStartTime={shift.shiftStartTime}
+                shiftEndTime={shift.shiftEndTime}
+                note={shift.note}
+              />
+            );
+          })
         ) : (
           <NoVolunteerShiftsRow firstName={firstName} status="scheduled" />
         )}

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerShiftsTable.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { Text, VStack } from "@chakra-ui/react";
+import { ShiftSignupPostingResponseDTO } from "../../../../types/api/ShiftSignupTypes";
+import VolunteerShiftsRow from "./VolunteerShiftsRow";
+import NoVolunteerShiftsRow from "./NoVolunteerShiftsRow";
+
+type VolunteerShiftsTableProps = {
+  firstName: string;
+  shifts: ShiftSignupPostingResponseDTO[];
+};
+
+const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
+  firstName,
+  shifts,
+}: VolunteerShiftsTableProps): React.ReactElement => {
+  return (
+    <VStack
+      w="full"
+      h="full"
+      spacing={0}
+      borderLeft="1px"
+      borderBottom="1px"
+      borderColor="background.dark"
+    >
+      <VStack
+        spacing="0px"
+        w="full"
+        px="32px"
+        py="16px"
+        alignItems="flex-start"
+        borderTop="1px"
+        borderBottom="1px"
+        borderColor="background.dark"
+      >
+        <Text textStyle="body-bold">Requested Shifts</Text>=
+      </VStack>
+
+      <VStack w="full" spacing={0} overflow="auto">
+        {shifts?.filter((shift) => shift.status === "PENDING").length > 0 ? (
+          shifts
+            ?.filter((shift) => shift.status === "PENDING")
+            .map((shift, i) => {
+              return (
+                <VolunteerShiftsRow
+                  key={i}
+                  postingTitle={shift.postingTitle}
+                  shiftStartTime={shift.shiftStartTime}
+                  shiftEndTime={shift.shiftEndTime}
+                  note={shift.note}
+                />
+              );
+            })
+        ) : (
+          <NoVolunteerShiftsRow firstName={firstName} status="requested" />
+        )}
+      </VStack>
+
+      <VStack
+        spacing="0px"
+        w="full"
+        px="32px"
+        py="16px"
+        alignItems="flex-start"
+        borderTop="1px"
+        borderBottom="1px"
+        borderColor="background.dark"
+      >
+        <Text textStyle="body-bold">Scheduled Shifts</Text>
+      </VStack>
+
+      <VStack w="full" spacing={0} overflow="auto">
+        {shifts?.filter((shift) => shift.status === "CONFIRMED").length > 0 ? (
+          shifts
+            ?.filter((shift) => shift.status === "CONFIRMED")
+            .map((shift, i) => {
+              return (
+                <VolunteerShiftsRow
+                  key={i}
+                  postingTitle={shift.postingTitle}
+                  shiftStartTime={shift.shiftStartTime}
+                  shiftEndTime={shift.shiftEndTime}
+                  note={shift.note}
+                />
+              );
+            })
+        ) : (
+          <NoVolunteerShiftsRow firstName={firstName} status="scheduled" />
+        )}
+      </VStack>
+    </VStack>
+  );
+};
+
+export default VolunteerShiftsTable;

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerSidePanel.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerSidePanel.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { VStack } from "@chakra-ui/react";
+import { gql, useQuery } from "@apollo/client";
+
+import VolunteerSkillsSection from "./VolunteerSkillsSection";
+import VolunteerShiftsTable from "./VolunteerShiftsTable";
+import VolunteerNameHeader from "./VolunteerNameHeader";
+import ErrorModal from "../../../common/ErrorModal";
+
+const PROFILE = gql`
+  query VolunteerProfile($userId: ID!) {
+    volunteerUserById(id: $userId) {
+      firstName
+      lastName
+      skills {
+        id
+        name
+      }
+    }
+    getShiftSignupsForUser(userId: $userId) {
+      postingTitle
+      shiftStartTime
+      shiftEndTime
+      note
+      status
+    }
+  }
+`;
+
+type VolunteerSidePanelProps = {
+  onVolunteerProfileClick: (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => void;
+  volunteerId: string;
+};
+
+const VolunteerSidePanel: React.FC<VolunteerSidePanelProps> = ({
+  onVolunteerProfileClick,
+  volunteerId,
+}: VolunteerSidePanelProps): React.ReactElement => {
+  const {
+    error: profileError,
+    loading: profileLoading,
+    data: {
+      volunteerUserById: volunteerDetails,
+      getShiftSignupsForUser: shiftDetails,
+    } = {},
+  } = useQuery(PROFILE, {
+    variables: { userId: volunteerId },
+    fetchPolicy: "cache-and-network",
+  });
+
+  return (
+    <VStack
+      w="full"
+      h="full"
+      spacing={0}
+      borderLeft="2px"
+      borderColor="background.dark"
+      alignItems="flex-start"
+    >
+      {profileError && <ErrorModal />}
+
+      <VolunteerNameHeader
+        profileLoading={profileLoading}
+        firstName={volunteerDetails?.firstName}
+        lastName={volunteerDetails?.lastName}
+        onVolunteerProfileClick={onVolunteerProfileClick}
+      />
+
+      {profileLoading ? (
+        <VStack
+          spacing="0px"
+          w="full"
+          h="full"
+          px="32px"
+          py="16px"
+          alignItems="flex-start"
+          borderTop="1px"
+          borderLeft="1px"
+          borderBottom="1px"
+          borderColor="background.dark"
+        />
+      ) : (
+        <>
+          <VolunteerSkillsSection skills={volunteerDetails?.skills} />
+          <VolunteerShiftsTable
+            firstName={volunteerDetails?.firstName}
+            shifts={shiftDetails}
+          />
+        </>
+      )}
+    </VStack>
+  );
+};
+
+export default VolunteerSidePanel;

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerSkillsSection.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerSkillsSection.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Box, Tag, Text, VStack } from "@chakra-ui/react";
+import { SkillResponseDTO } from "../../../../types/api/SkillTypes";
+
+type VolunteerSkillsSectionProps = {
+  skills: SkillResponseDTO[];
+};
+
+const VolunteerSkillsSection: React.FC<VolunteerSkillsSectionProps> = ({
+  skills,
+}: VolunteerSkillsSectionProps): React.ReactElement => {
+  return (
+    <VStack
+      spacing="0px"
+      w="full"
+      px="32px"
+      py="16px"
+      alignItems="flex-start"
+      borderTop="1px"
+      borderLeft="1px"
+      borderBottom="1px"
+      borderColor="background.dark"
+    >
+      <Text textStyle="body-bold">Skills</Text>
+      <Box>
+        {skills?.map((skill) => (
+          <Tag key={skill.name} variant="outline" mr={2} mt={2}>
+            {skill.name}
+          </Tag>
+        ))}
+      </Box>
+    </VStack>
+  );
+};
+
+export default VolunteerSkillsSection;

--- a/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerSkillsSection.tsx
+++ b/frontend/src/components/admin/schedule/volunteersidepanel/VolunteerSkillsSection.tsx
@@ -23,11 +23,17 @@ const VolunteerSkillsSection: React.FC<VolunteerSkillsSectionProps> = ({
     >
       <Text textStyle="body-bold">Skills</Text>
       <Box>
-        {skills?.map((skill) => (
-          <Tag key={skill.name} variant="outline" mr={2} mt={2}>
-            {skill.name}
-          </Tag>
-        ))}
+        {skills.length > 0 ? (
+          skills?.map((skill) => (
+            <Tag key={skill.name} variant="outline" mr={2} mt={2}>
+              {skill.name}
+            </Tag>
+          ))
+        ) : (
+          <Text textStyle="body-regular" fontSize="14px">
+            No skills listed.
+          </Text>
+        )}
       </Box>
     </VStack>
   );

--- a/frontend/src/components/pages/admin/schedule/NoShiftsPanel.tsx
+++ b/frontend/src/components/pages/admin/schedule/NoShiftsPanel.tsx
@@ -4,7 +4,13 @@ import { ADMIN_SCHEDULE_NO_SHIFTS } from "../../../../constants/Copy";
 
 const NoShiftsPanel = (): React.ReactElement => {
   return (
-    <Center h="full" borderLeft="2px" borderColor="background.dark" px="100px">
+    <Center
+      h="full"
+      borderLeft="1px"
+      borderTop="1px"
+      borderColor="background.dark"
+      px="100px"
+    >
       <Text textStyle="heading" color="text.gray">
         {ADMIN_SCHEDULE_NO_SHIFTS}
       </Text>

--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -349,15 +349,15 @@ const SchedulePostingPage = (): React.ReactElement => {
       ),
     ) === PostingFilterStatus.PAST;
 
-    const [volunteerId, setVolunteerId] = useState("");
+  const [volunteerId, setVolunteerId] = useState("");
 
-    const handleVolunteerProfileClick = (
-      isDisplayingVolunteer: boolean,
-      userId: string,
-    ) => {
-      setDisplayVolunteerSidePanel(isDisplayingVolunteer);
-      setVolunteerId(userId);
-    };
+  const handleVolunteerProfileClick = (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => {
+    setDisplayVolunteerSidePanel(isDisplayingVolunteer);
+    setVolunteerId(userId);
+  };
 
   return (
     <Flex flexFlow="column" width="100%" height="100vh">

--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -20,6 +20,7 @@ import ErrorModal from "../../../common/ErrorModal";
 import MonthViewShiftCalendar from "../../../admin/ShiftCalendar/MonthViewShiftCalendar";
 import AdminScheduleTable from "../../../admin/schedule/AdminScheduleTable";
 import ScheduleSidePanel from "../../../admin/schedule/ScheduleSidePanel";
+import VolunteerSidePanel from "../../../admin/schedule/volunteersidepanel/VolunteerSidePanel";
 import Loading from "../../../common/Loading";
 import { getUTCDateForDateTimeString } from "../../../../utils/DateTimeUtils";
 import AuthContext from "../../../../contexts/AuthContext";
@@ -144,6 +145,9 @@ const SchedulePostingPage = (): React.ReactElement => {
   const [currentView, setCurrentView] = useState<AdminScheduleViews>(
     AdminScheduleViews.CalendarView,
   );
+  const [displayVolunteerSidePanel, setDisplayVolunteerSidePanel] = useState(
+    false,
+  );
   const [
     submitSignups,
     { loading: submitSignupsLoading, error: submitSignupsError },
@@ -262,11 +266,17 @@ const SchedulePostingPage = (): React.ReactElement => {
     }
   };
 
-  const handleDayClick = (calendarDate: Date) => setSelectedDay(calendarDate);
+  const handleDayClick = (calendarDate: Date) => {
+    setSelectedDay(calendarDate);
+    setDisplayVolunteerSidePanel(false);
+  };
 
   const handleShiftClick = (
     shift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO,
-  ) => setSelectedShift(shift);
+  ) => {
+    setSelectedShift(shift);
+    setDisplayVolunteerSidePanel(false);
+  };
 
   const handleSidePanelSaveClick = async () => {
     if (!currentlyEditingShift) return;
@@ -339,6 +349,16 @@ const SchedulePostingPage = (): React.ReactElement => {
       ),
     ) === PostingFilterStatus.PAST;
 
+    const [volunteerId, setVolunteerId] = useState("");
+
+    const handleVolunteerProfileClick = (
+      isDisplayingVolunteer: boolean,
+      userId: string,
+    ) => {
+      setDisplayVolunteerSidePanel(isDisplayingVolunteer);
+      setVolunteerId(userId);
+    };
+
   return (
     <Flex flexFlow="column" width="100%" height="100vh">
       {(tableDataQueryError || submitSignupsError || postingError) && (
@@ -373,18 +393,26 @@ const SchedulePostingPage = (): React.ReactElement => {
             )}
           </Box>
           <Box w="400px" overflow="hidden">
-            <ScheduleSidePanel
-              shifts={sidePanelShifts}
-              currentlyEditingShift={currentlyEditingShift}
-              onEditSignupsClick={handleSidePanelEditClick}
-              onSelectAllSignupsClick={handleSelectAllSignupsClick}
-              onSignupCheckboxClick={handleSignupCheckboxClick}
-              onSaveSignupsClick={handleSidePanelSaveClick}
-              submitSignupsLoading={submitSignupsLoading}
-              selectedShift={selectedShift}
-              setSelectedShift={setSelectedShift}
-              isReadOnly={isReadOnly}
-            />
+            {displayVolunteerSidePanel ? (
+              <VolunteerSidePanel
+                onVolunteerProfileClick={handleVolunteerProfileClick}
+                volunteerId={volunteerId}
+              />
+            ) : (
+              <ScheduleSidePanel
+                shifts={sidePanelShifts}
+                currentlyEditingShift={currentlyEditingShift}
+                onEditSignupsClick={handleSidePanelEditClick}
+                onSelectAllSignupsClick={handleSelectAllSignupsClick}
+                onSignupCheckboxClick={handleSignupCheckboxClick}
+                onSaveSignupsClick={handleSidePanelSaveClick}
+                submitSignupsLoading={submitSignupsLoading}
+                selectedShift={selectedShift}
+                setSelectedShift={setSelectedShift}
+                isReadOnly={isReadOnly}
+                onVolunteerProfileClick={handleVolunteerProfileClick}
+              />
+            )}
           </Box>
         </Flex>
       ) : (

--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -145,9 +145,6 @@ const SchedulePostingPage = (): React.ReactElement => {
   const [currentView, setCurrentView] = useState<AdminScheduleViews>(
     AdminScheduleViews.CalendarView,
   );
-  const [displayVolunteerSidePanel, setDisplayVolunteerSidePanel] = useState(
-    false,
-  );
   const [
     submitSignups,
     { loading: submitSignupsLoading, error: submitSignupsError },
@@ -266,16 +263,29 @@ const SchedulePostingPage = (): React.ReactElement => {
     }
   };
 
+  const [volunteerId, setVolunteerId] = useState("");
+  const [displayVolunteerSidePanel, setDisplayVolunteerSidePanel] = useState(
+    false,
+  );
+
+  const handleVolunteerProfileClick = (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => {
+    setDisplayVolunteerSidePanel(isDisplayingVolunteer);
+    setVolunteerId(userId);
+  };
+
   const handleDayClick = (calendarDate: Date) => {
     setSelectedDay(calendarDate);
-    setDisplayVolunteerSidePanel(false);
+    handleVolunteerProfileClick(false, "");
   };
 
   const handleShiftClick = (
     shift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO,
   ) => {
     setSelectedShift(shift);
-    setDisplayVolunteerSidePanel(false);
+    handleVolunteerProfileClick(false, "");
   };
 
   const handleSidePanelSaveClick = async () => {
@@ -349,15 +359,12 @@ const SchedulePostingPage = (): React.ReactElement => {
       ),
     ) === PostingFilterStatus.PAST;
 
-  const [volunteerId, setVolunteerId] = useState("");
-
-  const handleVolunteerProfileClick = (
-    isDisplayingVolunteer: boolean,
-    userId: string,
-  ) => {
-    setDisplayVolunteerSidePanel(isDisplayingVolunteer);
-    setVolunteerId(userId);
-  };
+  useEffect(() => {
+    return () => {
+      setVolunteerId("");
+      setDisplayVolunteerSidePanel(false);
+    };
+  }, []);
 
   return (
     <Flex flexFlow="column" width="100%" height="100vh">

--- a/frontend/src/types/api/ShiftSignupTypes.ts
+++ b/frontend/src/types/api/ShiftSignupTypes.ts
@@ -12,4 +12,5 @@ export type ShiftSignupPostingResponseDTO = {
   postingId: string;
   postingTitle: string;
   autoClosingDate: string;
+  note: string;
 };

--- a/frontend/src/utils/DateTimeUtils.ts
+++ b/frontend/src/utils/DateTimeUtils.ts
@@ -45,6 +45,17 @@ export const formatDateStringYear = (dateStringInput: string): string => {
 
 /**
  * @param {string} dateStringInput date string on frontend
+ * @returns corresponding date string in the following format (Mon, Oct 13, 2021)
+ */
+export const formatDateStringYearAbbrWeekday = (
+  dateStringInput: string,
+): string => {
+  const inputAsDate = new Date(dateStringInput);
+  return moment(inputAsDate).utc().format("ddd, ll");
+};
+
+/**
+ * @param {string} dateStringInput date string on frontend
  * @returns corresponding date string in the following format (Monday, Oct 13)
  */
 export const formatDateMonthDay = (dateStringInput: string): string => {


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #505 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created the volunteer profile side bar
* Used `volunteerUserById` and `getShiftSignupsForUser` queries to get all the info needed

![image](https://user-images.githubusercontent.com/30396273/180586417-1e5ef02d-b29e-48ca-b263-ce2cc692af06.png)

With local repo seed:
![image](https://user-images.githubusercontent.com/30396273/180586466-e3ee7f28-d362-4334-aca5-88304ed8ea1a.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to `.../admin/schedule/posting/1` (or /2), click on a shift that has available volunteers, and then click the profile icon of a volunteer
2. Ensure the site doesn't crash, and navigate between volunteers and shifts (the side panel should either display volunteer profiles or shift information)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Review implementation logic
* Review empty state design implementations (i.e. when there are no skills listed, or no shifts of a certain type)


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
