### PR TITLE
Migrate DoB and pronouns to user model

### DIFF
--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -24,7 +24,7 @@ const userType = gql`
     email: String!
     role: Role!
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
   }
 
   type VolunteerUserResponseDTO {
@@ -39,7 +39,7 @@ const userType = gql`
     emergencyContactEmail: String
     hireDate: Date
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
     skills: [SkillResponseDTO!]!
     branches: [BranchResponseDTO!]!
     languages: [Language]!
@@ -56,7 +56,7 @@ const userType = gql`
     emergencyContactEmail: String
     hireDate: Date
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
     languages: [Language]!
   }
 
@@ -71,7 +71,7 @@ const userType = gql`
     emergencyContactPhone: String
     emergencyContactEmail: String
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
     branches: [BranchResponseDTO!]!
     languages: [Language]!
   }
@@ -87,7 +87,7 @@ const userType = gql`
     emergencyContactPhone: String
     emergencyContactEmail: String
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
   }
 
   type UserInviteResponse {
@@ -106,7 +106,7 @@ const userType = gql`
     emergencyContactPhone: String
     emergencyContactEmail: String
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
   }
 
   input CreateVolunteerUserDTO {
@@ -120,7 +120,7 @@ const userType = gql`
     password: String!
     hireDate: Date!
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
     skills: [ID!]!
     branches: [ID!]!
     languages: [Language]!
@@ -137,7 +137,7 @@ const userType = gql`
     emergencyContactEmail: String
     hireDate: Date!
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
     skills: [ID!]!
     branches: [ID!]!
     languages: [Language]!
@@ -152,7 +152,7 @@ const userType = gql`
     emergencyContactPhone: String
     emergencyContactEmail: String
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
     password: String!
     branches: [ID!]!
     languages: [Language]!
@@ -168,7 +168,7 @@ const userType = gql`
     emergencyContactPhone: String
     emergencyContactEmail: String
     dateOfBirth: Date
-    pronouns: String
+    pronouns: String!
     branches: [ID!]!
     languages: [Language]!
   }

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -23,6 +23,8 @@ const userType = gql`
     lastName: String!
     email: String!
     role: Role!
+    dateOfBirth: Date
+    pronouns: String
   }
 
   type VolunteerUserResponseDTO {
@@ -68,6 +70,8 @@ const userType = gql`
     emergencyContactName: String
     emergencyContactPhone: String
     emergencyContactEmail: String
+    dateOfBirth: Date
+    pronouns: String
     branches: [BranchResponseDTO!]!
     languages: [Language]!
   }
@@ -82,6 +86,8 @@ const userType = gql`
     emergencyContactName: String
     emergencyContactPhone: String
     emergencyContactEmail: String
+    dateOfBirth: Date
+    pronouns: String
   }
 
   type UserInviteResponse {
@@ -99,6 +105,8 @@ const userType = gql`
     emergencyContactName: String
     emergencyContactPhone: String
     emergencyContactEmail: String
+    dateOfBirth: Date
+    pronouns: String
   }
 
   input CreateVolunteerUserDTO {
@@ -143,6 +151,8 @@ const userType = gql`
     emergencyContactName: String
     emergencyContactPhone: String
     emergencyContactEmail: String
+    dateOfBirth: Date
+    pronouns: String
     password: String!
     branches: [ID!]!
     languages: [Language]!
@@ -157,6 +167,8 @@ const userType = gql`
     emergencyContactName: String
     emergencyContactPhone: String
     emergencyContactEmail: String
+    dateOfBirth: Date
+    pronouns: String
     branches: [ID!]!
     languages: [Language]!
   }

--- a/backend/prisma/migrations/20220731144814_made_do_b_and_pronouns_part_of_user/migration.sql
+++ b/backend/prisma/migrations/20220731144814_made_do_b_and_pronouns_part_of_user/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `date_of_birth` on the `volunteers` table. All the data in the column will be lost.
+  - You are about to drop the column `pronouns` on the `volunteers` table. All the data in the column will be lost.
+  - Added the required column `pronouns` to the `users` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "date_of_birth" TIMESTAMP(3),
+ADD COLUMN     "pronouns" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "volunteers" DROP COLUMN "date_of_birth",
+DROP COLUMN "pronouns";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -38,6 +38,8 @@ model User {
   languages             Language[]
   createdAt             DateTime   @default(now())
   updatedAt             DateTime   @updatedAt
+  dateOfBirth           DateTime?  @map("date_of_birth")
+  pronouns              String
 
   @@map("users")
 }
@@ -155,15 +157,13 @@ model Signup {
 }
 
 model Volunteer {
-  id          Int       @id
-  user        User      @relation(fields: [id], references: [id], onDelete: Cascade)
-  branches    Branch[]
-  hireDate    DateTime  @map("hire_date")
-  skills      Skill[]
-  dateOfBirth DateTime? @map("date_of_birth")
-  pronouns    String
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id        Int      @id
+  user      User     @relation(fields: [id], references: [id], onDelete: Cascade)
+  branches  Branch[]
+  hireDate  DateTime @map("hire_date")
+  skills    Skill[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@map("volunteers")
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -205,6 +205,7 @@ const main = async () => {
           lastName: user.lastName,
           authId: user.authId,
           role: user.role,
+          pronouns: "they/them",
           employee: {
             create: {},
           },
@@ -229,6 +230,7 @@ const main = async () => {
           lastName: employee.lastName,
           authId: employee.authId,
           role: employee.role,
+          pronouns: "they/them",
           employee: {
             create: {
               branches: {
@@ -264,6 +266,7 @@ const main = async () => {
           lastName: user.lastName,
           authId: user.authId,
           role: user.role,
+          pronouns: "they/them",
           volunteer: {
             create: {
               ...user.volunteer,

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -54,10 +54,10 @@ const volunteerUsers = [
     lastName: "Volunteer",
     authId: process.env.VOLUNTEER_UID,
     role: Role.VOLUNTEER,
+    dateOfBirth: new Date("August 19, 2000 23:15:30"),
+    pronouns: "they/them",
     volunteer: {
-      pronouns: "they/them",
       hireDate: new Date(),
-      dateOfBirth: new Date("August 19, 2000 23:15:30"),
       branches: [{ name: Branches.Arts }],
       skills: [
         { name: Skills.Cooking },
@@ -72,10 +72,10 @@ const volunteerUsers = [
     lastName: "Volunteer",
     authId: process.env.VOLUNTEER1_UID,
     role: Role.VOLUNTEER,
+    dateOfBirth: new Date("August 19, 2000 23:15:30"),
+    pronouns: "she/her",
     volunteer: {
-      pronouns: "she/her",
       hireDate: addDays(new Date(), -7),
-      dateOfBirth: new Date("August 19, 2000 23:15:30"),
       branches: [{ name: Branches.Kitchen }],
       skills: [],
     },

--- a/backend/services/implementations/__tests__/userService.test.ts
+++ b/backend/services/implementations/__tests__/userService.test.ts
@@ -9,12 +9,14 @@ const testUsers = [
     lastName: "Pan",
     authId: "123",
     role: Role.ADMIN,
+    pronouns: "They/them",
   },
   {
     firstName: "Wendy",
     lastName: "Darling",
     authId: "321",
     role: Role.ADMIN,
+    pronouns: "They/them",
   },
 ];
 

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -534,7 +534,7 @@ class UserService implements IUserService {
             },
           });
         })
-        .catch(() => { });
+        .catch(() => {});
 
       if (user !== null) {
         throw new Error(

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -870,7 +870,7 @@ class UserService implements IUserService {
                 emergencyContactName: volunteerUser.emergencyContactName,
                 emergencyContactPhone: volunteerUser.emergencyContactPhone,
                 emergencyContactEmail: volunteerUser.emergencyContactEmail,
-                pronouns: volunteerUser.pronouns ?? "",
+                pronouns: volunteerUser.pronouns,
                 dateOfBirth: volunteerUser.dateOfBirth ?? "",
               },
             },
@@ -993,7 +993,7 @@ class UserService implements IUserService {
               emergencyContactName: deletedVolunteerUser.emergencyContactName,
               emergencyContactPhone: deletedVolunteerUser.emergencyContactPhone,
               emergencyContactEmail: deletedVolunteerUser.emergencyContactEmail,
-              pronouns: deletedVolunteerUser.pronouns ?? "",
+              pronouns: deletedVolunteerUser.pronouns,
               dateOfBirth: deletedVolunteerUser.dateOfBirth ?? "",
               volunteer: {
                 create: {

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -88,6 +88,8 @@ class UserService implements IUserService {
       emergencyContactName: user.emergencyContactName,
       emergencyContactPhone: user.emergencyContactPhone,
       emergencyContactEmail: user.emergencyContactEmail,
+      pronouns: user.pronouns,
+      dateOfBirth: user.dateOfBirth,
     };
   }
 
@@ -122,6 +124,8 @@ class UserService implements IUserService {
       emergencyContactName: user.emergencyContactName,
       emergencyContactPhone: user.emergencyContactPhone,
       emergencyContactEmail: user.emergencyContactEmail,
+      pronouns: user.pronouns,
+      dateOfBirth: user.dateOfBirth,
     };
   }
 
@@ -207,6 +211,8 @@ class UserService implements IUserService {
             emergencyContactName: user.emergencyContactName,
             emergencyContactPhone: user.emergencyContactPhone,
             emergencyContactEmail: user.emergencyContactEmail,
+            pronouns: user.pronouns,
+            dateOfBirth: user.dateOfBirth,
           };
         }),
       );
@@ -245,6 +251,8 @@ class UserService implements IUserService {
             emergencyContactName: user.emergencyContactName,
             emergencyContactPhone: user.emergencyContactPhone,
             emergencyContactEmail: user.emergencyContactEmail,
+            pronouns: user.pronouns,
+            dateOfBirth: user.dateOfBirth,
           },
         });
       } catch (postgresError) {
@@ -278,6 +286,8 @@ class UserService implements IUserService {
       emergencyContactName: newUser.emergencyContactName,
       emergencyContactPhone: newUser.emergencyContactPhone,
       emergencyContactEmail: newUser.emergencyContactEmail,
+      pronouns: newUser.pronouns,
+      dateOfBirth: newUser.dateOfBirth,
     };
   }
 
@@ -304,6 +314,8 @@ class UserService implements IUserService {
             emergencyContactName: user.emergencyContactName,
             emergencyContactPhone: user.emergencyContactPhone,
             emergencyContactEmail: user.emergencyContactEmail,
+            pronouns: user.pronouns,
+            dateOfBirth: user.dateOfBirth,
           },
         }),
       ]);
@@ -332,6 +344,8 @@ class UserService implements IUserService {
               emergencyContactName: oldUser.emergencyContactName,
               emergencyContactPhone: oldUser.emergencyContactPhone,
               emergencyContactEmail: oldUser.emergencyContactEmail,
+              pronouns: oldUser.pronouns,
+              dateOfBirth: oldUser.dateOfBirth,
             },
           });
         } catch (postgresError: unknown) {
@@ -362,6 +376,8 @@ class UserService implements IUserService {
       emergencyContactName: user.emergencyContactName,
       emergencyContactPhone: user.emergencyContactPhone,
       emergencyContactEmail: user.emergencyContactEmail,
+      pronouns: user.pronouns,
+      dateOfBirth: user.dateOfBirth,
     };
   }
 
@@ -388,6 +404,8 @@ class UserService implements IUserService {
               emergencyContactName: deletedUser.emergencyContactName,
               emergencyContactPhone: deletedUser.emergencyContactPhone,
               emergencyContactEmail: deletedUser.emergencyContactEmail,
+              pronouns: deletedUser.pronouns,
+              dateOfBirth: deletedUser.dateOfBirth,
             },
           });
         } catch (postgresError: unknown) {
@@ -435,6 +453,8 @@ class UserService implements IUserService {
               emergencyContactName: deletedUser.emergencyContactName,
               emergencyContactPhone: deletedUser.emergencyContactPhone,
               emergencyContactEmail: deletedUser.emergencyContactEmail,
+              pronouns: deletedUser.pronouns,
+              dateOfBirth: deletedUser.dateOfBirth,
             },
           });
         } catch (postgresError: unknown) {
@@ -739,11 +759,11 @@ class UserService implements IUserService {
             emergencyContactName: volunteerUser.emergencyContactName,
             emergencyContactPhone: volunteerUser.emergencyContactPhone,
             emergencyContactEmail: volunteerUser.emergencyContactEmail,
+            pronouns: volunteerUser.pronouns ?? "",
+            dateOfBirth: volunteerUser.dateOfBirth,
             volunteer: {
               create: {
                 hireDate: volunteerUser.hireDate,
-                pronouns: volunteerUser.pronouns ?? "",
-                dateOfBirth: volunteerUser.dateOfBirth,
                 branches: {
                   connect: convertToNumberIds(volunteerUser.branches),
                 },
@@ -830,8 +850,6 @@ class UserService implements IUserService {
           },
           data: {
             hireDate: volunteerUser.hireDate,
-            pronouns: volunteerUser.pronouns ?? "",
-            dateOfBirth: volunteerUser.dateOfBirth ?? "",
             branches: {
               set: [], // setting the related branches to be [] before connecting the passed in values
               connect: convertToNumberIds(volunteerUser.branches),
@@ -850,6 +868,8 @@ class UserService implements IUserService {
                 emergencyContactName: volunteerUser.emergencyContactName,
                 emergencyContactPhone: volunteerUser.emergencyContactPhone,
                 emergencyContactEmail: volunteerUser.emergencyContactEmail,
+                pronouns: volunteerUser.pronouns ?? "",
+                dateOfBirth: volunteerUser.dateOfBirth ?? "",
               },
             },
           },
@@ -874,8 +894,6 @@ class UserService implements IUserService {
           id: String(user.id),
           email: updatedFirebaseUser.email ?? "",
           hireDate: updatedVolunteerUser.hireDate,
-          dateOfBirth: updatedVolunteerUser.dateOfBirth,
-          pronouns: updatedVolunteerUser.pronouns,
           skills: convertToSkillResponseDTO(updatedVolunteerUser.skills),
           branches: convertToBranchResponseDTO(updatedVolunteerUser.branches),
         };
@@ -888,10 +906,6 @@ class UserService implements IUserService {
             data: {
               /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
               hireDate: oldVolunteerUser!.hireDate,
-              /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-              pronouns: oldVolunteerUser!.pronouns,
-              /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-              dateOfBirth: oldVolunteerUser!.dateOfBirth,
               branches: {
                 /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
                 connect: oldVolunteerUser!.branches,
@@ -919,6 +933,10 @@ class UserService implements IUserService {
                   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
                   emergencyContactEmail: oldVolunteerUser!.user
                     .emergencyContactEmail,
+                  /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+                  pronouns: oldVolunteerUser!.pronouns,
+                  /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+                  dateOfBirth: oldVolunteerUser!.dateOfBirth,
                 },
               },
             },
@@ -973,14 +991,12 @@ class UserService implements IUserService {
               emergencyContactName: deletedVolunteerUser.emergencyContactName,
               emergencyContactPhone: deletedVolunteerUser.emergencyContactPhone,
               emergencyContactEmail: deletedVolunteerUser.emergencyContactEmail,
+              pronouns: deletedVolunteerUser.pronouns ?? "",
+              dateOfBirth: deletedVolunteerUser.dateOfBirth ?? "",
               volunteer: {
                 create: {
                   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
                   hireDate: deletedVolunteer!.hireDate,
-                  /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-                  pronouns: deletedVolunteer!.pronouns ?? "",
-                  /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-                  dateOfBirth: deletedVolunteer!.dateOfBirth ?? "",
                   branches: {
                     /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
                     connect: deletedVolunteer!.branches.map((b) => {
@@ -1056,6 +1072,8 @@ class UserService implements IUserService {
         emergencyContactPhone: user.emergencyContactPhone,
         emergencyContactEmail: user.emergencyContactEmail,
         branches: convertToBranchResponseDTO(employee.branches),
+        pronouns: user.pronouns,
+        dateOfBirth: user.dateOfBirth,
       };
     } catch (error: unknown) {
       Logger.error(
@@ -1101,6 +1119,8 @@ class UserService implements IUserService {
         role: user.role,
         languages: user.languages,
         branches: convertToBranchResponseDTO(employee.branches),
+        pronouns: user.pronouns,
+        dateOfBirth: user.dateOfBirth,
       };
     } catch (error: unknown) {
       Logger.error(
@@ -1195,6 +1215,8 @@ class UserService implements IUserService {
             emergencyContactName: employeeUser.emergencyContactName,
             emergencyContactPhone: employeeUser.emergencyContactPhone,
             emergencyContactEmail: employeeUser.emergencyContactEmail,
+            pronouns: employeeUser.pronouns,
+            dateOfBirth: employeeUser.dateOfBirth,
             employee: {
               create: {
                 branches: {
@@ -1276,6 +1298,8 @@ class UserService implements IUserService {
               emergencyContactPhone: employeeUser.emergencyContactPhone,
               emergencyContactEmail: employeeUser.emergencyContactEmail,
               languages: employeeUser.languages,
+              pronouns: employeeUser.pronouns,
+              dateOfBirth: employeeUser.dateOfBirth,
             },
           },
           branches: {
@@ -1329,6 +1353,10 @@ class UserService implements IUserService {
                   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
                   emergencyContactEmail: oldEmployeeUser!.user
                     .emergencyContactEmail,
+                  /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+                  pronouns: oldEmployeeUser!.user.pronouns,
+                  /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+                  dateOfBirth: oldEmployeeUser!.user.dateOfBirth,
                 },
               },
               branches: {
@@ -1387,6 +1415,8 @@ class UserService implements IUserService {
               emergencyContactName: deletedEmployeeUser.emergencyContactName,
               emergencyContactPhone: deletedEmployeeUser.emergencyContactPhone,
               emergencyContactEmail: deletedEmployeeUser.emergencyContactEmail,
+              pronouns: deletedEmployeeUser.pronouns,
+              dateOfBirth: deletedEmployeeUser.dateOfBirth,
               employee: {
                 create: {
                   branches: {

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -534,7 +534,7 @@ class UserService implements IUserService {
             },
           });
         })
-        .catch(() => {});
+        .catch(() => { });
 
       if (user !== null) {
         throw new Error(
@@ -611,9 +611,9 @@ class UserService implements IUserService {
         emergencyContactName: user.emergencyContactName,
         emergencyContactPhone: user.emergencyContactPhone,
         emergencyContactEmail: user.emergencyContactEmail,
+        dateOfBirth: user.dateOfBirth,
+        pronouns: user.pronouns,
         hireDate: volunteer.hireDate,
-        dateOfBirth: volunteer.dateOfBirth,
-        pronouns: volunteer.pronouns,
         languages: user.languages,
         skills: convertToSkillResponseDTO(volunteer.skills),
         branches: convertToBranchResponseDTO(volunteer.branches),
@@ -661,9 +661,9 @@ class UserService implements IUserService {
         emergencyContactName: user.emergencyContactName,
         emergencyContactPhone: user.emergencyContactPhone,
         emergencyContactEmail: user.emergencyContactEmail,
+        dateOfBirth: user.dateOfBirth,
+        pronouns: user.pronouns,
         hireDate: volunteer.hireDate,
-        dateOfBirth: volunteer.dateOfBirth,
-        pronouns: volunteer.pronouns,
         skills: convertToSkillResponseDTO(volunteer.skills),
         branches: convertToBranchResponseDTO(volunteer.branches),
         languages: user.languages,
@@ -765,7 +765,7 @@ class UserService implements IUserService {
             emergencyContactName: volunteerUser.emergencyContactName,
             emergencyContactPhone: volunteerUser.emergencyContactPhone,
             emergencyContactEmail: volunteerUser.emergencyContactEmail,
-            pronouns: volunteerUser.pronouns ?? "",
+            pronouns: volunteerUser.pronouns,
             dateOfBirth: volunteerUser.dateOfBirth,
             volunteer: {
               create: {
@@ -797,10 +797,6 @@ class UserService implements IUserService {
           email: firebaseUser.email ?? "",
           /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
           hireDate: volunteer!.hireDate,
-          /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-          dateOfBirth: volunteer!.dateOfBirth,
-          /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-          pronouns: volunteer!.pronouns,
           /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
           skills: convertToSkillResponseDTO(volunteer!.skills),
           /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
@@ -940,9 +936,9 @@ class UserService implements IUserService {
                   emergencyContactEmail: oldVolunteerUser!.user
                     .emergencyContactEmail,
                   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-                  pronouns: oldVolunteerUser!.pronouns,
+                  pronouns: oldVolunteerUser!.user.pronouns,
                   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-                  dateOfBirth: oldVolunteerUser!.dateOfBirth,
+                  dateOfBirth: oldVolunteerUser!.user.dateOfBirth,
                 },
               },
             },

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -30,6 +30,8 @@ export type UserDTO = {
   emergencyContactName: string | null;
   emergencyContactPhone: string | null;
   emergencyContactEmail: string | null;
+  dateOfBirth: Date | null;
+  pronouns: string | null;
 };
 
 export type PostingDTO = {
@@ -64,8 +66,6 @@ export type PostingResponseDTO = Omit<
 export type VolunteerDTO = {
   id: string;
   hireDate: Date;
-  dateOfBirth: Date | null;
-  pronouns: string | null;
   skills: SkillResponseDTO[];
   branches: BranchResponseDTO[];
 };

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -31,7 +31,7 @@ export type UserDTO = {
   emergencyContactPhone: string | null;
   emergencyContactEmail: string | null;
   dateOfBirth: Date | null;
-  pronouns: string | null;
+  pronouns: string;
 };
 
 export type PostingDTO = {

--- a/frontend/src/components/pages/EditAccountPage.tsx
+++ b/frontend/src/components/pages/EditAccountPage.tsx
@@ -25,6 +25,8 @@ const EMPLOYEE_BY_ID = gql`
       firstName
       lastName
       email
+      dateOfBirth
+      pronouns
       phoneNumber
       emergencyContactPhone
       languages

--- a/frontend/src/components/user/AccountForm.tsx
+++ b/frontend/src/components/user/AccountForm.tsx
@@ -230,6 +230,8 @@ const AccountForm = ({
           emergencyContactEmail: "",
           emergencyContactName: "",
           emergencyContactPhone: values.emergencyNumber,
+          pronouns: values.pronouns,
+          dateOfBirth: values.dateOfBirth,
           password: values.password,
           languages: values.languages.map(
             (language) => LANGUAGES[Number(language.id) - 1],
@@ -272,6 +274,8 @@ const AccountForm = ({
           emergencyContactEmail: "",
           emergencyContactName: "",
           emergencyContactPhone: values.emergencyNumber,
+          pronouns: values.pronouns,
+          dateOfBirth: values.dateOfBirth,
           languages: values.languages.map(
             (language) => LANGUAGES[Number(language.id) - 1],
           ),

--- a/frontend/src/types/api/EmployeeTypes.ts
+++ b/frontend/src/types/api/EmployeeTypes.ts
@@ -11,6 +11,8 @@ export type EmployeeUserDTO = {
   emergencyContactName: string | null;
   emergencyContactPhone: string | null;
   emergencyContactEmail: string | null;
+  pronouns: string | null;
+  dateOfBirth: string | null;
   branches: BranchResponseDTO[];
   languages: Language[];
 };

--- a/frontend/src/types/api/UserType.ts
+++ b/frontend/src/types/api/UserType.ts
@@ -26,14 +26,14 @@ export type UserDTO = {
   emergencyContactName: string | null;
   emergencyContactPhone: string | null;
   emergencyContactEmail: string | null;
+  dateOfBirth: string | null;
+  pronouns: string | null;
   branches: BranchResponseDTO[];
 };
 
 export type VolunteerDTO = {
   id: string;
   hireDate: string;
-  dateOfBirth: string | null;
-  pronouns: string | null;
   skills: SkillResponseDTO[];
 };
 


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #503


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed prisma schema, changed corresponding types in backend and frontend, as well as to graphql schemas.
* 
<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Use any query with users and they will now have pronouns and date of birth associated with them.

As a general note: I noticed that, while the prisma schema originally made pronouns essential and dateOfBirth nullable, the typing in types didnt reflect that (sometimes both were nullable). How important is it that the type `string` vs `string | null`?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
