### PR TITLE
Remove backend logout call on refresh failure and reload window

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,6 @@ import { ChakraProvider } from "@chakra-ui/react";
 
 import { hotjar } from "react-hotjar";
 import ReactGA from "react-ga";
-import { gql, useMutation } from "@apollo/client";
 import Login from "./components/auth/Login";
 import Signup from "./components/auth/Signup";
 import ResetPassword from "./components/auth/ResetPassword";
@@ -58,7 +57,6 @@ import AdminUserManagementPage from "./components/pages/admin/user/AdminUserMana
 import CreatePostingPage from "./components/pages/admin/posting/CreatePostingPage";
 import EditAccountPage from "./components/pages/EditAccountPage";
 import EditPostingPage from "./components/pages/admin/posting/EditPostingPage";
-import authAPIClient from "./APIClients/AuthAPIClient";
 
 // Consts for Hotjar and Google Analytics (this is ok to expose)
 const TRACKING_ID = "G-DF2BP4T8YQ";
@@ -68,6 +66,14 @@ const HSJV = 6;
 ReactGA.initialize(TRACKING_ID);
 
 const App = (): React.ReactElement => {
+  useEffect(() => {
+    ReactGA.pageview(window.location.pathname + window.location.search);
+  }, []);
+
+  useEffect(() => {
+    hotjar.initialize(HJID, HSJV);
+  }, []);
+
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
     AUTHENTICATED_USER_KEY,
   );
@@ -88,14 +94,6 @@ const App = (): React.ReactElement => {
     postingContextReducer,
     DEFAULT_POSTING_CONTEXT,
   );
-
-  useEffect(() => {
-    ReactGA.pageview(window.location.pathname + window.location.search);
-  }, []);
-
-  useEffect(() => {
-    hotjar.initialize(HJID, HSJV);
-  }, []);
 
   return (
     <ChakraProvider theme={customTheme}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,12 +65,6 @@ const TRACKING_ID = "G-DF2BP4T8YQ";
 const HJID = 2949419;
 const HSJV = 6;
 
-const REFRESH = gql`
-  mutation Refresh {
-    refresh
-  }
-`;
-
 ReactGA.initialize(TRACKING_ID);
 
 const App = (): React.ReactElement => {
@@ -94,8 +88,6 @@ const App = (): React.ReactElement => {
     postingContextReducer,
     DEFAULT_POSTING_CONTEXT,
   );
-
-  const [refresh] = useMutation<{ refresh: string }>(REFRESH);
 
   useEffect(() => {
     ReactGA.pageview(window.location.pathname + window.location.search);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,14 +105,6 @@ const App = (): React.ReactElement => {
     hotjar.initialize(HJID, HSJV);
   }, []);
 
-  useEffect(() => {
-    authAPIClient.refresh(refresh).then((response) => {
-      if (!response.valueOf()) {
-        setAuthenticatedUser(null);
-      }
-    });
-  }, [refresh]);
-
   return (
     <ChakraProvider theme={customTheme}>
       <SampleContext.Provider value={sampleContext}>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -22,13 +22,8 @@ const REFRESH_MUTATION = `
     refresh
   }
 `;
-const LOGOUT = `
-  mutation Index_Logout($userId: ID!) {
-    logout(userId: $userId)
-  }
-`;
 
-const logout = async (userId: string) => {
+const logout = async () => {
   localStorage.removeItem(AUTHENTICATED_USER_KEY);
   window.location.reload();
 };
@@ -69,9 +64,7 @@ const authLink = setContext(async (_, { headers }) => {
         );
         token = accessToken;
       } catch {
-        await logout(
-          String(getLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "id")),
-        );
+        await logout();
       }
     }
   }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -22,7 +22,6 @@ const REFRESH_MUTATION = `
     refresh
   }
 `;
-
 const LOGOUT = `
   mutation Index_Logout($userId: ID!) {
     logout(userId: $userId)
@@ -30,15 +29,8 @@ const LOGOUT = `
 `;
 
 const logout = async (userId: string) => {
-  const { data: result } = await axios.post(
-    `${process.env.REACT_APP_BACKEND_URL}/graphql`,
-    { query: LOGOUT, variables: { userId } },
-    { withCredentials: true },
-  );
-
-  if (result?.data?.logout === null) {
-    localStorage.removeItem(AUTHENTICATED_USER_KEY);
-  }
+  localStorage.removeItem(AUTHENTICATED_USER_KEY);
+  window.location.reload();
 };
 
 const link = createUploadLink({


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #513 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `UseEffect` in `App.tsx` to refresh pages automatically if Access Token expires


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to Network tab on the Console Inspect
2. he first 200 GraphQL response and on `Headers` you should see a refresh token. Copy that.
3. Refresh the page
4.  Navigate to at 200 GraphQL response again and the refresh token should be the same as the access token.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
