### PR TITLE
Add missing posting detail links to admin posting cards

### DIFF
--- a/frontend/src/components/admin/AdminPostingCard.tsx
+++ b/frontend/src/components/admin/AdminPostingCard.tsx
@@ -34,6 +34,7 @@ type AdminPostingCardProps = {
   numVolunteers: number;
   navigateToAdminSchedule?: () => void;
   navigateToEditPosting?: () => void;
+  navigateToPostingDetails?: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
 };
@@ -50,6 +51,7 @@ const AdminPostingCard = ({
   numVolunteers,
   navigateToAdminSchedule,
   navigateToEditPosting,
+  navigateToPostingDetails,
   onDuplicate,
   onDelete,
 }: AdminPostingCardProps): React.ReactElement => {
@@ -95,7 +97,12 @@ const AdminPostingCard = ({
               </Menu>
             )}
           </HStack>
-          <Text noOfLines={1} textStyle="heading">
+          <Text
+            noOfLines={1}
+            textStyle="heading"
+            cursor="pointer"
+            onClick={navigateToPostingDetails}
+          >
             {status === PostingFilterStatus.DRAFT && (
               <Box as="span" mr={1} color="red">
                 [DRAFT]

--- a/frontend/src/components/pages/admin/AdminHomepage.tsx
+++ b/frontend/src/components/pages/admin/AdminHomepage.tsx
@@ -121,6 +121,11 @@ const AdminHomepage = (): React.ReactElement => {
     history.push(route);
   };
 
+  const navigateToPostingDetails = (id: string) => {
+    const route = generatePath(Routes.ADMIN_POSTING_DETAILS, { id });
+    history.push(route);
+  };
+
   useQuery<BranchQueryResponse>(BRANCHES, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
@@ -243,6 +248,9 @@ const AdminHomepage = (): React.ReactElement => {
                       }
                       navigateToEditPosting={() =>
                         navigateToEditPosting(posting.id)
+                      }
+                      navigateToPostingDetails={() =>
+                        navigateToPostingDetails(posting.id)
                       }
                       onDuplicate={() => duplicatePostingById(posting.id)}
                       onDelete={() => deletePostingById(posting.id)}

--- a/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
+++ b/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
@@ -7,7 +7,6 @@ import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import PostingDetails from "../../../common/PostingDetails";
 import ErrorModal from "../../../common/ErrorModal";
-import { ADMIN_SCHEDULE_POSTING_NAV } from "../../../../constants/Routes";
 
 const POSTING = gql`
   query AdminPostingDetails_Posting($id: ID!) {
@@ -58,11 +57,9 @@ const AdminPostingDetails = (): React.ReactElement => {
             <Button
               leftIcon={<ChevronLeftIcon />}
               variant="link"
-              onClick={() =>
-                history.push(`${ADMIN_SCHEDULE_POSTING_NAV}/${id}`)
-              }
+              onClick={() => history.goBack()}
             >
-              Back to editing
+              Back
             </Button>
           </Flex>
         </Container>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #552

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add missing posting details link to admin posting card by linking to appropriate existing page via `history.push`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. As a admin, I can click on any posting card under any tab in admin homepage (`/admin`) to view its posting details

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Any regressions
* Code cleanliness

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
