### PR TITLE
Clear posting context before visiting new create or edit posting pages

### DIFF
--- a/frontend/src/components/admin/AdminHomepageHeader.tsx
+++ b/frontend/src/components/admin/AdminHomepageHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React, { Dispatch, SetStateAction, useContext, useState } from "react";
 import {
   VStack,
   HStack,
@@ -17,6 +17,8 @@ import {
 import { AddIcon, SearchIcon, SettingsIcon } from "@chakra-ui/icons";
 import { useHistory } from "react-router-dom";
 import BranchManagerModal from "./BranchManagerModal";
+import { ADMIN_CREATE_POSTING_PAGE } from "../../constants/Routes";
+import PostingContextDispatcherContext from "../../contexts/admin/PostingContextDispatcherContext";
 import { BranchResponseDTO } from "../../types/api/BranchTypes";
 
 type AdminHomepageHeaderProps = {
@@ -40,6 +42,7 @@ const AdminHomepageHeader = ({
 }: AdminHomepageHeaderProps): React.ReactElement => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const history = useHistory();
+  const dispatchPostingUpdate = useContext(PostingContextDispatcherContext);
 
   return (
     <>
@@ -54,7 +57,12 @@ const AdminHomepageHeader = ({
           <Text textStyle="display-small-semibold">Volunteer Postings</Text>
           <Spacer />
           {isSuperAdmin && (
-            <Button onClick={() => history.push("/admin/posting/create")}>
+            <Button
+              onClick={() => {
+                dispatchPostingUpdate({ type: "ADMIN_POSTING_RESET" });
+                history.push(ADMIN_CREATE_POSTING_PAGE);
+              }}
+            >
               <AddIcon boxSize={3} mr={3} />
               Create new posting
             </Button>

--- a/frontend/src/components/pages/admin/AdminHomepage.tsx
+++ b/frontend/src/components/pages/admin/AdminHomepage.tsx
@@ -3,6 +3,7 @@ import { Flex, Box, SimpleGrid, useToast } from "@chakra-ui/react";
 import { generatePath, useHistory } from "react-router-dom";
 import { gql, useMutation, useQuery } from "@apollo/client";
 import AuthContext from "../../../contexts/AuthContext";
+import PostingContextDispatcherContext from "../../../contexts/admin/PostingContextDispatcherContext";
 import * as Routes from "../../../constants/Routes";
 
 import Navbar from "../../common/Navbar";
@@ -89,6 +90,7 @@ const filterAdminPosting = (
 const AdminHomepage = (): React.ReactElement => {
   const history = useHistory();
   const { authenticatedUser } = useContext(AuthContext);
+  const dispatchPostingUpdate = useContext(PostingContextDispatcherContext);
   const [isSuperAdmin] = useState(authenticatedUser?.role === Role.Admin);
   const [postings, setPostings] = useState<SimplePostingResponseDTO[] | null>(
     null,
@@ -125,6 +127,7 @@ const AdminHomepage = (): React.ReactElement => {
   };
 
   const navigateToEditPosting = (id: string) => {
+    dispatchPostingUpdate({ type: "ADMIN_POSTING_RESET" });
     const route = generatePath(Routes.ADMIN_EDIT_POSTING_PAGE, { id });
     history.push(route);
   };

--- a/frontend/src/reducers/PostingContextReducer.ts
+++ b/frontend/src/reducers/PostingContextReducer.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_POSTING_CONTEXT } from "../contexts/admin/PostingContext";
 import {
   PostingContextAction,
   PostingContextType,
@@ -73,6 +74,10 @@ export default (
       return {
         ...state,
         recurrenceInterval: action.value,
+      };
+    case "ADMIN_POSTING_RESET":
+      return {
+        ...DEFAULT_POSTING_CONTEXT,
       };
     default:
       return state;

--- a/frontend/src/types/PostingContextTypes.ts
+++ b/frontend/src/types/PostingContextTypes.ts
@@ -76,4 +76,7 @@ export type PostingContextAction =
   | {
       type: "ADMIN_POSTING_EDIT_RECURRENCE_INTERVAL";
       value: RecurrenceInterval;
+    }
+  | {
+      type: "ADMIN_POSTING_RESET";
     };


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #564


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* New `ADMIN_POSTING_RESET` reducer action for resetting posting context to default state
* Dispatches this action before beginning a new create or edit posting flow (i.e. before navigating to the create or edit pages from the admin home page)

Note: This addresses a more general case of the issue vs just clearing after saving to the backend. The posting context is modified before the save so we would still see leftover fields from the context if beginning a new create/edit after previously abandoning a create/edit part way through.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Use the preview deploy link and sign in as an admin
2. Create a new posting from the admin home page
3. Try to create another posting and verify that the form and posting context contain the default fields (can use React dev tools)
![image](https://user-images.githubusercontent.com/30205929/184285432-7aa95d40-1455-4a63-8f92-3057c051aaf3.png)
4. Open a posting in edit mode, verify that the form and context contain the expected fields
6. Try to create another posting and verify that the form and posting context contain the default fields and not fields of the last edited posting


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Any other weirdness around the posting context? In hindsight, maintaining fields in global state via context might have opened up room for a lot of edge cases 😬


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
