### PR TITLE
Implement Organization-Wide Calendar for Admins & Employees

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -146,6 +146,7 @@ const graphQLMiddlewares = {
     shift: authorizedByAdmin(),
     shifts: authorizedByAdmin(),
     shiftsByPosting: authorizedByAllRoles(),
+    shiftsWithSignupsAndVolunteers: authorizedByAdminAndVolunteer(),
     shiftsWithSignupsAndVolunteersByPosting: authorizedByAllRoles(),
     posting: authorizedByAllRoles(),
     postings: authorizedByAllRoles(),

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -146,7 +146,7 @@ const graphQLMiddlewares = {
     shift: authorizedByAdmin(),
     shifts: authorizedByAdmin(),
     shiftsByPosting: authorizedByAllRoles(),
-    shiftsWithSignupsAndVolunteers: authorizedByAdminAndVolunteer(),
+    shiftsWithSignupsAndVolunteers: authorizedByAdminAndEmployee(),
     shiftsWithSignupsAndVolunteersByPosting: authorizedByAllRoles(),
     posting: authorizedByAllRoles(),
     postings: authorizedByAllRoles(),

--- a/backend/graphql/resolvers/postingResolvers.ts
+++ b/backend/graphql/resolvers/postingResolvers.ts
@@ -1,6 +1,6 @@
 import PostingService from "../../services/implementations/postingService";
 import IPostingService from "../../services/interfaces/postingService";
-import IShiftService from "../../services/interfaces/IShiftService";
+import IShiftService from "../../services/interfaces/shiftService";
 import ShiftService from "../../services/implementations/shiftService";
 import UserService from "../../services/implementations/userService";
 import IUserService from "../../services/interfaces/userService";

--- a/backend/graphql/resolvers/shiftResolvers.ts
+++ b/backend/graphql/resolvers/shiftResolvers.ts
@@ -1,6 +1,6 @@
 import { SignupStatus } from "@prisma/client";
 import ShiftService from "../../services/implementations/shiftService";
-import IShiftService from "../../services/interfaces/IShiftService";
+import IShiftService from "../../services/interfaces/shiftService";
 import {
   ShiftBulkRequestDTO,
   ShiftRequestDTO,
@@ -26,6 +26,11 @@ const shiftResolvers = {
       { postingId }: { postingId: string },
     ): Promise<ShiftResponseDTO[]> => {
       return shiftService.getShiftsByPosting(postingId);
+    },
+    shiftsWithSignupsAndVolunteers: async (): Promise<
+      ShiftWithSignupAndVolunteerResponseDTO[]
+    > => {
+      return shiftService.getShiftsWithSignupsAndVolunteers();
     },
     shiftsWithSignupsAndVolunteersByPosting: async (
       _parent: undefined,

--- a/backend/graphql/types/shiftType.ts
+++ b/backend/graphql/types/shiftType.ts
@@ -40,6 +40,7 @@ const shiftType = gql`
     shift(id: ID!): ShiftResponseDTO!
     shifts: [ShiftResponseDTO!]!
     shiftsByPosting(postingId: ID!): [ShiftResponseDTO!]!
+    shiftsWithSignupsAndVolunteers: [ShiftWithSignupAndVolunteerResponseDTO!]!
     shiftsWithSignupsAndVolunteersByPosting(
       postingId: ID!
       userId: ID

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -24,7 +24,7 @@ import {
 } from "../../types";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
-import IShiftService from "../interfaces/IShiftService";
+import IShiftService from "../interfaces/shiftService";
 import { getInterval } from "../../utilities/dateUtils";
 
 const prisma = new PrismaClient();

--- a/backend/services/implementations/shiftService.ts
+++ b/backend/services/implementations/shiftService.ts
@@ -10,7 +10,7 @@ import {
 import { Promise as BluebirdPromise } from "bluebird";
 
 import moment from "moment";
-import IShiftService from "../interfaces/IShiftService";
+import IShiftService from "../interfaces/shiftService";
 import {
   ShiftBulkRequestDTO,
   ShiftBulkRequestWithoutPostingId,

--- a/backend/services/interfaces/shiftService.ts
+++ b/backend/services/interfaces/shiftService.ts
@@ -40,6 +40,15 @@ interface IShiftService {
   getShiftsByPosting(postingId: string): Promise<ShiftResponseDTO[]>;
 
   /**
+   * Gets all shift, signup, and volunteer info for all postings
+   * @returns array of ShiftWithSignupAndVolunteerResponseDTOs
+   * @throws Error if the shift retrieval fails
+   */
+  getShiftsWithSignupsAndVolunteers(): Promise<
+    ShiftWithSignupAndVolunteerResponseDTO[]
+  >;
+
+  /**
    * Gets all shift, signup and volunteer info for a given posting id, user
    * id, and signup status
    * @param postingId the target posting's id

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,15 +139,15 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.VOLUNTEER_POSTING_DETAILS}
-                  authorizedRoles={[Role.Volunteer]}
-                  component={VolunteerPostingDetails}
-                />
-                <PrivateRoute
-                  exact
                   path={Routes.VOLUNTEER_POSTING_AVAILABILITIES}
                   authorizedRoles={[Role.Volunteer]}
                   component={VolunteerPostingAvailabilities}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.VOLUNTEER_POSTING_DETAILS}
+                  authorizedRoles={[Role.Volunteer]}
+                  component={VolunteerPostingDetails}
                 />
                 <PrivateRoute
                   exact
@@ -175,12 +175,6 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.ADMIN_POSTING_DETAILS}
-                  authorizedRoles={[Role.Admin, Role.Employee]}
-                  component={AdminPostingDetails}
-                />
-                <PrivateRoute
-                  exact
                   path={Routes.ADMIN_CREATE_POSTING_PAGE}
                   authorizedRoles={[Role.Admin]}
                   component={CreatePostingPage}
@@ -193,15 +187,21 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.ADMIN_SCHEDULE_POSTING_PAGE}
+                  path={Routes.ADMIN_POSTING_DETAILS}
                   authorizedRoles={[Role.Admin, Role.Employee]}
-                  component={SchedulePostingPage}
+                  component={AdminPostingDetails}
                 />
                 <PrivateRoute
                   exact
                   path={Routes.ADMIN_SCHEDULE_POSTING_REVIEW_PAGE}
                   authorizedRoles={[Role.Admin]}
                   component={AdminSchedulePostingReviewPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_SCHEDULE_POSTING_PAGE}
+                  authorizedRoles={[Role.Admin, Role.Employee]}
+                  component={SchedulePostingPage}
                 />
                 <Route exact path="*" component={NotFound} />
               </Switch>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,7 @@ import AdminUserManagementPage from "./components/pages/admin/user/AdminUserMana
 import CreatePostingPage from "./components/pages/admin/posting/CreatePostingPage";
 import EditAccountPage from "./components/pages/EditAccountPage";
 import EditPostingPage from "./components/pages/admin/posting/EditPostingPage";
+import OrgWideCalendar from "./components/admin/calendar/OrgWideCalendar";
 
 // Consts for Hotjar and Google Analytics (this is ok to expose)
 const TRACKING_ID = "G-DF2BP4T8YQ";
@@ -84,6 +85,11 @@ const App = (): React.ReactElement => {
           >
             <Router>
               <Switch>
+                <PrivateRoute
+                  exact
+                  path={Routes.HOME_PAGE}
+                  component={Default}
+                />
                 <Route exact path={Routes.LOGIN_PAGE} component={Login} />
                 <Route
                   exact
@@ -99,6 +105,11 @@ const App = (): React.ReactElement => {
                   exact
                   path={Routes.NEW_ACCOUNT_PAGE}
                   component={NewAccountPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.EDIT_ACCOUNT_PAGE}
+                  component={EditAccountPage}
                 />
                 <Route
                   exact
@@ -117,43 +128,14 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.ADMIN_HOMEPAGE}
-                  authorizedRoles={[Role.Admin, Role.Employee]}
-                  component={AdminHomepage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.EDIT_ACCOUNT_PAGE}
-                  component={EditAccountPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.HOME_PAGE}
-                  component={Default}
+                  path={Routes.NOT_FOUND_PAGE}
+                  component={NotFound}
                 />
                 <PrivateRoute
                   exact
                   path={Routes.VOLUNTEER_POSTINGS_PAGE}
                   authorizedRoles={[Role.Volunteer]}
                   component={VolunteerPostingsPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.VOLUNTEER_SHIFTS_PAGE}
-                  authorizedRoles={[Role.Volunteer]}
-                  component={VolunteerShiftsPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.ADMIN_CREATE_POSTING_PAGE}
-                  authorizedRoles={[Role.Admin]}
-                  component={CreatePostingPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.ADMIN_EDIT_POSTING_PAGE}
-                  authorizedRoles={[Role.Admin]}
-                  component={EditPostingPage}
                 />
                 <PrivateRoute
                   exact
@@ -169,9 +151,45 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
+                  path={Routes.VOLUNTEER_SHIFTS_PAGE}
+                  authorizedRoles={[Role.Volunteer]}
+                  component={VolunteerShiftsPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_HOMEPAGE}
+                  authorizedRoles={[Role.Admin, Role.Employee]}
+                  component={AdminHomepage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_ORG_WIDE_CALENDAR}
+                  authorizedRoles={[Role.Admin, Role.Employee]}
+                  component={OrgWideCalendar}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_USER_MANAGMENT_PAGE}
+                  authorizedRoles={[Role.Admin]}
+                  component={AdminUserManagementPage}
+                />
+                <PrivateRoute
+                  exact
                   path={Routes.ADMIN_POSTING_DETAILS}
                   authorizedRoles={[Role.Admin, Role.Employee]}
                   component={AdminPostingDetails}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_CREATE_POSTING_PAGE}
+                  authorizedRoles={[Role.Admin]}
+                  component={CreatePostingPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_EDIT_POSTING_PAGE}
+                  authorizedRoles={[Role.Admin]}
+                  component={EditPostingPage}
                 />
                 <PrivateRoute
                   exact
@@ -184,17 +202,6 @@ const App = (): React.ReactElement => {
                   path={Routes.ADMIN_SCHEDULE_POSTING_REVIEW_PAGE}
                   authorizedRoles={[Role.Admin]}
                   component={AdminSchedulePostingReviewPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.ADMIN_USER_MANAGMENT_PAGE}
-                  authorizedRoles={[Role.Admin]}
-                  component={AdminUserManagementPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.NOT_FOUND_PAGE}
-                  component={NotFound}
                 />
                 <Route exact path="*" component={NotFound} />
               </Switch>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,15 +139,15 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.VOLUNTEER_POSTING_AVAILABILITIES}
-                  authorizedRoles={[Role.Volunteer]}
-                  component={VolunteerPostingAvailabilities}
-                />
-                <PrivateRoute
-                  exact
                   path={Routes.VOLUNTEER_POSTING_DETAILS}
                   authorizedRoles={[Role.Volunteer]}
                   component={VolunteerPostingDetails}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.VOLUNTEER_POSTING_AVAILABILITIES}
+                  authorizedRoles={[Role.Volunteer]}
+                  component={VolunteerPostingAvailabilities}
                 />
                 <PrivateRoute
                   exact
@@ -193,15 +193,15 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.ADMIN_SCHEDULE_POSTING_REVIEW_PAGE}
-                  authorizedRoles={[Role.Admin]}
-                  component={AdminSchedulePostingReviewPage}
-                />
-                <PrivateRoute
-                  exact
                   path={Routes.ADMIN_SCHEDULE_POSTING_PAGE}
                   authorizedRoles={[Role.Admin, Role.Employee]}
                   component={SchedulePostingPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_SCHEDULE_POSTING_REVIEW_PAGE}
+                  authorizedRoles={[Role.Admin]}
+                  component={AdminSchedulePostingReviewPage}
                 />
                 <Route exact path="*" component={NotFound} />
               </Switch>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,15 +139,15 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.VOLUNTEER_POSTING_DETAILS}
-                  authorizedRoles={[Role.Volunteer]}
-                  component={VolunteerPostingDetails}
-                />
-                <PrivateRoute
-                  exact
                   path={Routes.VOLUNTEER_POSTING_AVAILABILITIES}
                   authorizedRoles={[Role.Volunteer]}
                   component={VolunteerPostingAvailabilities}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.VOLUNTEER_POSTING_DETAILS}
+                  authorizedRoles={[Role.Volunteer]}
+                  component={VolunteerPostingDetails}
                 />
                 <PrivateRoute
                   exact
@@ -193,27 +193,15 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
-                  path={Routes.ADMIN_CREATE_POSTING_PAGE}
+                  path={Routes.ADMIN_SCHEDULE_POSTING_REVIEW_PAGE}
                   authorizedRoles={[Role.Admin]}
-                  component={CreatePostingPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.ADMIN_EDIT_POSTING_PAGE}
-                  authorizedRoles={[Role.Admin]}
-                  component={EditPostingPage}
+                  component={AdminSchedulePostingReviewPage}
                 />
                 <PrivateRoute
                   exact
                   path={Routes.ADMIN_SCHEDULE_POSTING_PAGE}
                   authorizedRoles={[Role.Admin, Role.Employee]}
                   component={SchedulePostingPage}
-                />
-                <PrivateRoute
-                  exact
-                  path={Routes.ADMIN_SCHEDULE_POSTING_REVIEW_PAGE}
-                  authorizedRoles={[Role.Admin]}
-                  component={AdminSchedulePostingReviewPage}
                 />
                 <Route exact path="*" component={NotFound} />
               </Switch>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -193,6 +193,18 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
+                  path={Routes.ADMIN_CREATE_POSTING_PAGE}
+                  authorizedRoles={[Role.Admin]}
+                  component={CreatePostingPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.ADMIN_EDIT_POSTING_PAGE}
+                  authorizedRoles={[Role.Admin]}
+                  component={EditPostingPage}
+                />
+                <PrivateRoute
+                  exact
                   path={Routes.ADMIN_SCHEDULE_POSTING_PAGE}
                   authorizedRoles={[Role.Admin, Role.Employee]}
                   component={SchedulePostingPage}

--- a/frontend/src/components/admin/AdminHomepageHeader.tsx
+++ b/frontend/src/components/admin/AdminHomepageHeader.tsx
@@ -17,7 +17,10 @@ import {
 import { AddIcon, SearchIcon, SettingsIcon } from "@chakra-ui/icons";
 import { useHistory } from "react-router-dom";
 import BranchManagerModal from "./BranchManagerModal";
-import { ADMIN_CREATE_POSTING_PAGE } from "../../constants/Routes";
+import {
+  ADMIN_CREATE_POSTING_PAGE,
+  ADMIN_ORG_WIDE_CALENDAR,
+} from "../../constants/Routes";
 import PostingContextDispatcherContext from "../../contexts/admin/PostingContextDispatcherContext";
 import { BranchResponseDTO } from "../../types/api/BranchTypes";
 
@@ -56,17 +59,25 @@ const AdminHomepageHeader = ({
         <HStack w="full" mb="16px">
           <Text textStyle="display-small-semibold">Volunteer Postings</Text>
           <Spacer />
-          {isSuperAdmin && (
+          <HStack>
             <Button
-              onClick={() => {
-                dispatchPostingUpdate({ type: "ADMIN_POSTING_RESET" });
-                history.push(ADMIN_CREATE_POSTING_PAGE);
-              }}
+              variant="outline"
+              onClick={() => history.push(ADMIN_ORG_WIDE_CALENDAR)}
             >
-              <AddIcon boxSize={3} mr={3} />
-              Create new posting
+              View Calendar
             </Button>
-          )}
+            {isSuperAdmin && (
+              <Button
+                onClick={() => {
+                  dispatchPostingUpdate({ type: "ADMIN_POSTING_RESET" });
+                  history.push(ADMIN_CREATE_POSTING_PAGE);
+                }}
+              >
+                <AddIcon boxSize={3} mr={3} />
+                Create new posting
+              </Button>
+            )}
+          </HStack>
         </HStack>
         <HStack w="full" alignItems="flex-start" spacing={0}>
           <Tabs pt="10px">

--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
-import { Box, Button, Flex, Select, Spacer } from "@chakra-ui/react";
+import { Box, Button, Center, Flex, Select, Spacer } from "@chakra-ui/react";
 import moment from "moment";
 import React, { useEffect } from "react";
 import { AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO } from "../../../types/api/ShiftTypes";
@@ -40,7 +40,7 @@ const MonthViewShiftCalendar = ({
     const sortedEventsList = sortEvents(events);
     setSortedEvents(sortedEventsList);
     if (moment(selectedMonth).diff(moment(new Date(0)), "days") === 0) {
-      setSelectedMonth(getFirstDayOfMonth(sortedEventsList[0].start));
+      setSelectedMonth(getFirstDayOfMonth(sortedEventsList[0]?.start));
     }
   }, [events, selectedMonth]);
 
@@ -125,7 +125,7 @@ const MonthViewShiftCalendar = ({
       />
     </Box>
   ) : (
-    <Box>No events to display</Box>
+    <Center mt={8}>No events to display</Center>
   );
 };
 

--- a/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthViewShiftCalendar.tsx
@@ -39,8 +39,11 @@ const MonthViewShiftCalendar = ({
   useEffect(() => {
     const sortedEventsList = sortEvents(events);
     setSortedEvents(sortedEventsList);
-    if (moment(selectedMonth).diff(moment(new Date(0)), "days") === 0) {
-      setSelectedMonth(getFirstDayOfMonth(sortedEventsList[0]?.start));
+    if (
+      moment(selectedMonth).diff(moment(new Date(0)), "days") === 0 &&
+      sortedEventsList.length > 0
+    ) {
+      setSelectedMonth(getFirstDayOfMonth(sortedEventsList[0].start));
     }
   }, [events, selectedMonth]);
 

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -247,11 +247,9 @@ const OrgWideCalendar = (): React.ReactElement => {
         <Box flex={1}>
           <AdminSchedulePageHeader
             branchName={
-              selectedShift
-                ? userPostings.find(
-                    (userPosting) => userPosting.id === selectedShift.postingId,
-                  )?.branch.name || "Organization-Wide"
-                : "Organization-Wide"
+              userPostings.find(
+                (userPosting) => userPosting.id === selectedShift.postingId,
+              )?.branch.name || "Organization-Wide"
             }
           />
           {ReadOnlyAdminPostingScheduleHeader({

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -1,10 +1,186 @@
-import React from "react";
+import { gql, useQuery } from "@apollo/client";
+import { Box, Flex } from "@chakra-ui/react";
+import moment from "moment";
+import React, { useContext, useEffect, useState } from "react";
+import {
+  AdminNavbarTabs,
+  AdminPages,
+  EmployeeNavbarTabs,
+} from "../../../constants/Tabs";
+import AuthContext from "../../../contexts/AuthContext";
+import { AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO } from "../../../types/api/ShiftTypes";
+import { Role } from "../../../types/AuthTypes";
+import { getUTCDateForDateTimeString } from "../../../utils/DateTimeUtils";
+import ErrorModal from "../../common/ErrorModal";
+import Loading from "../../common/Loading";
+import Navbar from "../../common/Navbar";
+import ScheduleSidePanel from "../schedule/ScheduleSidePanel";
+import VolunteerSidePanel from "../schedule/volunteersidepanel/VolunteerSidePanel";
+import MonthViewShiftCalendar from "../ShiftCalendar/MonthViewShiftCalendar";
+
+type AdminOrgCalendarShiftsAndSignupsResponse = {
+  shiftsWithSignupsAndVolunteers: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[];
+};
+
+const ADMIN_ORG_CALENDAR_TABLE_DATA_QUERY = gql`
+  query AdminOrgCalendarShiftsAndSignups {
+    shiftsWithSignupsAndVolunteers {
+      id
+      postingId
+      startTime
+      endTime
+      signups {
+        shiftStartTime
+        shiftEndTime
+        numVolunteers
+        note
+        status
+        volunteer {
+          id
+          firstName
+          lastName
+        }
+      }
+    }
+  }
+`;
 
 const OrgWideCalendar = (): React.ReactElement => {
+  const { authenticatedUser } = useContext(AuthContext);
+  const [isSuperAdmin] = useState(authenticatedUser?.role === Role.Admin);
+  const [shifts, setShifts] = useState<
+    AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[]
+  >([]);
+  const [
+    selectedShift,
+    setSelectedShift,
+  ] = useState<AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO>(
+    shifts[0],
+  );
+  const [selectedDay, setSelectedDay] = useState<Date>();
+  const [sidePanelShifts, setSidePanelShifts] = useState<
+    AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO[]
+  >([]);
+  const [volunteerId, setVolunteerId] = useState("");
+  const [displayVolunteerSidePanel, setDisplayVolunteerSidePanel] = useState(
+    false,
+  );
+
+  const {
+    error: tableDataQueryError,
+    loading: tableDataLoading,
+  } = useQuery<AdminOrgCalendarShiftsAndSignupsResponse>(
+    ADMIN_ORG_CALENDAR_TABLE_DATA_QUERY,
+    {
+      onCompleted: ({ shiftsWithSignupsAndVolunteers: shiftsData }) => {
+        setShifts(shiftsData);
+
+        if (shiftsData.length) {
+          const firstDay = shiftsData[0]?.startTime;
+          setSelectedDay(firstDay);
+          setSidePanelShifts(
+            shiftsData.filter((shift) =>
+              moment(shift.startTime).isSame(moment(firstDay), "day"),
+            ),
+          );
+        }
+      },
+      fetchPolicy: "no-cache",
+    },
+  );
+
+  useEffect(() => {
+    const shiftsOfDay = shifts.filter((shift) =>
+      moment.utc(shift.startTime).isSame(moment.utc(selectedDay), "day"),
+    );
+    setSidePanelShifts(shiftsOfDay);
+    // Set selected shift to first shift if current selected is not in same day
+    if (
+      selectedShift &&
+      !moment
+        .utc(selectedShift.startTime)
+        .isSame(moment.utc(selectedDay), "day")
+    ) {
+      setSelectedShift(shiftsOfDay[0]);
+    }
+  }, [shifts, selectedDay, selectedShift]);
+
+  const handleVolunteerProfileClick = (
+    isDisplayingVolunteer: boolean,
+    userId: string,
+  ) => {
+    setDisplayVolunteerSidePanel(isDisplayingVolunteer);
+    setVolunteerId(userId);
+  };
+
+  const handleDayClick = (calendarDate: Date) => {
+    setSelectedDay(calendarDate);
+    handleVolunteerProfileClick(false, "");
+  };
+
+  const handleShiftClick = (
+    shift: AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO,
+  ) => {
+    setSelectedShift(shift);
+    handleVolunteerProfileClick(false, "");
+  };
+
   return (
-    <div>
-      <h1>OrgWideCalendar</h1>
-    </div>
+    <Flex flexFlow="column" width="100%" height="100vh">
+      {tableDataQueryError && <ErrorModal /> /* TODO: error */}
+      <Navbar
+        defaultIndex={Number(AdminPages.AdminSchedulePosting)}
+        tabs={isSuperAdmin ? AdminNavbarTabs : EmployeeNavbarTabs}
+      />
+
+      <Flex>
+        <Box flex={1}>
+          {tableDataLoading ? ( // TODO: loading
+            <Loading />
+          ) : (
+            shifts.length > 0 && (
+              <MonthViewShiftCalendar
+                events={shifts.map((shift) => {
+                  return {
+                    id: shift.id,
+                    start: getUTCDateForDateTimeString(
+                      shift.startTime.toString(),
+                    ),
+                    end: getUTCDateForDateTimeString(shift.endTime.toString()),
+                    groupId: "", // TODO: Add groupId for saved/unsaved
+                  };
+                })}
+                shifts={shifts}
+                onDayClick={handleDayClick}
+                onShiftClick={handleShiftClick}
+              />
+            )
+          )}
+        </Box>
+        <Box w="400px" overflow="hidden">
+          {displayVolunteerSidePanel ? (
+            <VolunteerSidePanel
+              onVolunteerProfileClick={handleVolunteerProfileClick}
+              volunteerId={volunteerId}
+            />
+          ) : (
+            <ScheduleSidePanel
+              shifts={sidePanelShifts}
+              currentlyEditingShift={selectedShift}
+              onEditSignupsClick={() => {}}
+              onSelectAllSignupsClick={() => {}}
+              onSignupCheckboxClick={() => {}}
+              onSaveSignupsClick={async () => {}}
+              submitSignupsLoading={false}
+              selectedShift={selectedShift}
+              setSelectedShift={setSelectedShift}
+              isReadOnly
+              onVolunteerProfileClick={handleVolunteerProfileClick}
+            />
+          )}
+        </Box>
+      </Flex>
+    </Flex>
   );
 };
 

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -248,7 +248,7 @@ const OrgWideCalendar = (): React.ReactElement => {
           <AdminSchedulePageHeader
             branchName={
               userPostings.find(
-                (userPosting) => userPosting.id === selectedShift.postingId,
+                (userPosting) => userPosting.id === selectedShift?.postingId,
               )?.branch.name || "Organization-Wide"
             }
           />

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -100,6 +100,7 @@ const ReadOnlyScheduleSidePanel = ({
       selectedShift={selectedShift}
       setSelectedShift={setSelectedShift}
       isReadOnly
+      isNotOpenForReview
       onVolunteerProfileClick={handleVolunteerProfileClick}
     />
   );
@@ -121,6 +122,7 @@ const ReadOnlyAdminPostingScheduleHeader = ({
         )?.title || ""
       }
       onReviewClick={() => {}}
+      isNotOpenForReview
       isReadOnly
     />
   ) : (

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -195,7 +195,7 @@ const OrgWideCalendar = (): React.ReactElement => {
   } = useQuery<AdminOrgCalendarPostings>(ADMIN_ORG_CALENDAR_POSTINGS, {
     variables: { id: authenticatedUser?.id },
     onCompleted: ({ postings }) => {
-      setUserPostings(postings);
+      setUserPostings(postings.map((posting) => posting.id));
       getShiftsAndSignups();
     },
     fetchPolicy: "no-cache",

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -195,7 +195,7 @@ const OrgWideCalendar = (): React.ReactElement => {
   } = useQuery<AdminOrgCalendarPostings>(ADMIN_ORG_CALENDAR_POSTINGS, {
     variables: { id: authenticatedUser?.id },
     onCompleted: ({ postings }) => {
-      setUserPostings(postings.map((posting) => posting.id));
+      setUserPostings(postings);
       getShiftsAndSignups();
     },
     fetchPolicy: "no-cache",

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -195,11 +195,7 @@ const OrgWideCalendar = (): React.ReactElement => {
 
   return (
     <Flex flexFlow="column" width="100%" height="100vh">
-      {
-        (tableDataQueryError || postingsQueryError) && (
-          <ErrorModal />
-        ) /* TODO: error */
-      }
+      {(tableDataQueryError || postingsQueryError) && <ErrorModal />}
       <Navbar
         defaultIndex={Number(AdminPages.AdminSchedulePosting)}
         tabs={isSuperAdmin ? AdminNavbarTabs : EmployeeNavbarTabs}
@@ -208,7 +204,7 @@ const OrgWideCalendar = (): React.ReactElement => {
       <Flex>
         <Box flex={1}>
           <AdminSchedulePageHeader branchName="Organization-Wide" />
-          {tableDataLoading || postingsLoading ? ( // TODO: loading
+          {tableDataLoading || postingsLoading ? (
             <Loading />
           ) : (
             <MonthViewShiftCalendar

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const OrgWideCalendar = (): React.ReactElement => {
+  return (
+    <div>
+      <h1>OrgWideCalendar</h1>
+    </div>
+  );
+};
+
+export default OrgWideCalendar;

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -12,8 +12,6 @@ export const EDIT_ACCOUNT_PAGE = "/edit-account";
 
 export const RESET_PASSWORD_PAGE = "/reset-password";
 
-export const ADMIN_HOMEPAGE = "/admin";
-
 export const RESET_PASSWORD_SUCCESS_PAGE = "/password-reset-success";
 
 export const DONE_RESET_PASSWORD_PAGE = "/done-reset-password";
@@ -22,24 +20,26 @@ export const NOT_FOUND_PAGE = "/not-found";
 
 export const VOLUNTEER_POSTINGS_PAGE = "/volunteer/postings";
 
+export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
+
 export const VOLUNTEER_POSTING_AVAILABILITIES =
   "/volunteer/posting/:id/availabilities";
 
-export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
-
 export const VOLUNTEER_SHIFTS_PAGE = "/volunteer/shifts";
+
+export const ADMIN_HOMEPAGE = "/admin";
+
+export const ADMIN_ORG_WIDE_CALENDAR = "/admin/calendar";
+
+export const ADMIN_USER_MANAGMENT_PAGE = "/admin/users";
+
+export const ADMIN_POSTING_DETAILS = "/admin/posting/:id";
 
 export const ADMIN_CREATE_POSTING_PAGE = "/admin/posting/create";
 
 export const ADMIN_EDIT_POSTING_PAGE = "/admin/posting/edit/:id";
 
-export const ADMIN_ORG_WIDE_CALENDAR = "/admin/calendar";
-
-export const ADMIN_POSTING_DETAILS = "/admin/posting/:id";
-
 export const ADMIN_SCHEDULE_POSTING_PAGE = "/admin/schedule/posting/:id";
 
 export const ADMIN_SCHEDULE_POSTING_REVIEW_PAGE =
   "/admin/schedule/posting/:id/review";
-
-export const ADMIN_USER_MANAGMENT_PAGE = "/admin/users";

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -20,10 +20,10 @@ export const NOT_FOUND_PAGE = "/not-found";
 
 export const VOLUNTEER_POSTINGS_PAGE = "/volunteer/postings";
 
-export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
-
 export const VOLUNTEER_POSTING_AVAILABILITIES =
   "/volunteer/posting/:id/availabilities";
+
+export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
 
 export const VOLUNTEER_SHIFTS_PAGE = "/volunteer/shifts";
 
@@ -33,13 +33,13 @@ export const ADMIN_ORG_WIDE_CALENDAR = "/admin/calendar";
 
 export const ADMIN_USER_MANAGMENT_PAGE = "/admin/users";
 
-export const ADMIN_POSTING_DETAILS = "/admin/posting/:id";
-
 export const ADMIN_CREATE_POSTING_PAGE = "/admin/posting/create";
 
 export const ADMIN_EDIT_POSTING_PAGE = "/admin/posting/edit/:id";
 
-export const ADMIN_SCHEDULE_POSTING_PAGE = "/admin/schedule/posting/:id";
+export const ADMIN_POSTING_DETAILS = "/admin/posting/:id";
 
 export const ADMIN_SCHEDULE_POSTING_REVIEW_PAGE =
   "/admin/schedule/posting/:id/review";
+
+export const ADMIN_SCHEDULE_POSTING_PAGE = "/admin/schedule/posting/:id";

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -20,10 +20,10 @@ export const NOT_FOUND_PAGE = "/not-found";
 
 export const VOLUNTEER_POSTINGS_PAGE = "/volunteer/postings";
 
+export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
+
 export const VOLUNTEER_POSTING_AVAILABILITIES =
   "/volunteer/posting/:id/availabilities";
-
-export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
 
 export const VOLUNTEER_SHIFTS_PAGE = "/volunteer/shifts";
 

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -20,10 +20,10 @@ export const NOT_FOUND_PAGE = "/not-found";
 
 export const VOLUNTEER_POSTINGS_PAGE = "/volunteer/postings";
 
-export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
-
 export const VOLUNTEER_POSTING_AVAILABILITIES =
   "/volunteer/posting/:id/availabilities";
+
+export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
 
 export const VOLUNTEER_SHIFTS_PAGE = "/volunteer/shifts";
 

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -22,26 +22,24 @@ export const NOT_FOUND_PAGE = "/not-found";
 
 export const VOLUNTEER_POSTINGS_PAGE = "/volunteer/postings";
 
+export const VOLUNTEER_POSTING_AVAILABILITIES =
+  "/volunteer/posting/:id/availabilities";
+
+export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
+
 export const VOLUNTEER_SHIFTS_PAGE = "/volunteer/shifts";
 
 export const ADMIN_CREATE_POSTING_PAGE = "/admin/posting/create";
 
 export const ADMIN_EDIT_POSTING_PAGE = "/admin/posting/edit/:id";
 
-export const VOLUNTEER_POSTING_DETAILS = "/volunteer/posting/:id";
+export const ADMIN_ORG_WIDE_CALENDAR = "/admin/calendar";
 
 export const ADMIN_POSTING_DETAILS = "/admin/posting/:id";
-
-export const ADMIN_SCHEDULE_POSTING_NAV = "/admin/schedule/posting";
 
 export const ADMIN_SCHEDULE_POSTING_PAGE = "/admin/schedule/posting/:id";
 
 export const ADMIN_SCHEDULE_POSTING_REVIEW_PAGE =
   "/admin/schedule/posting/:id/review";
-
-export const VOLUNTEER_POSTING_AVAILABILITIES =
-  "/volunteer/posting/:id/availabilities";
-
-export const ADMIN_SCHEDULE_POSTINGS_PAGE = "/admin/schedule";
 
 export const ADMIN_USER_MANAGMENT_PAGE = "/admin/users";

--- a/frontend/src/types/api/ShiftTypes.ts
+++ b/frontend/src/types/api/ShiftTypes.ts
@@ -31,10 +31,7 @@ export type ShiftWithSignupAndVolunteerResponseDTO = ShiftResponseDTO & {
   signups: SignupsAndVolunteerResponseDTO[];
 };
 
-export type AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO = Omit<
-  ShiftDTO,
-  "postingId"
-> & {
+export type AdminScheduleShiftWithSignupAndVolunteerGraphQLResponseDTO = ShiftDTO & {
   signups: AdminSchedulingSignupsAndVolunteerResponseDTO[];
 };
 


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #535 
Closes #555 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a new query `shiftsWithSignupsAndVolunteers` (of the shiftService) to return all posting's shifts with signups and volunteers.
* Created the org wide calendar page at `/admin/calendar`. This calendar displays the **scheduled/past** signups and volunteers from all postings across Sistering.
* Some clean-up work
  * Renamed IShiftService.ts to shiftService.ts on the backend to keep interface file naming convention.
  * Re-ordered routes for better organization
* Extended `getUserBranchesByUserId` functionality to also work for employees and admins (this is used in `getPostings`, which is then called in the frontend for employees and admins)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to [](http://localhost:3000/admin/calendar) as a super admin, should see all scheduled and past postings in any branch.
2. Navigate to the same screen as an admin, should only see scheduled and past postings from your own branch.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctly displaying events


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
