### PR TITLE
Remove unused admin reset user password button

### DIFF
--- a/frontend/src/components/admin/users/ProfileDrawer.tsx
+++ b/frontend/src/components/admin/users/ProfileDrawer.tsx
@@ -168,10 +168,6 @@ const ProfileDrawer = ({
         </DrawerBody>
         <Divider />
         <DrawerFooter>
-          {/* this button might be removed depending on reset pw flow */}
-          <Button variant="outline" mr={3}>
-            Reset password
-          </Button>
           <Button colorScheme="red" onClick={() => setOpenDeleteModal(true)}>
             Remove user
           </Button>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #540


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove unused button in user management profile drawer reset password button


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `admin/users` route in preview, ensure that the reset password button is no longer visible


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
No regression


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
