### PR TITLE
Add clickable logo on signup nav and customize tabs on edit-account ✨ 

### DIFF
--- a/frontend/src/components/common/SignupNavbar.tsx
+++ b/frontend/src/components/common/SignupNavbar.tsx
@@ -7,7 +7,13 @@ const SignupNavbar = (): React.ReactElement => {
   return (
     <Box px="90px" boxShadow="md">
       <Flex h="80px" alignItems="center" justifyContent="space-between">
-        <Image src={Sistering_Logo} alt="Sistering logo" h={14} />
+        <Link
+          href="/"
+          _focus={{ boxShadow: "none" }}
+          _hover={{ transform: "scale(1.1)" }}
+        >
+          <Image src={Sistering_Logo} alt="Sistering logo" h={14} />
+        </Link>
         <Link href="https://sistering.org/">Back to Main</Link>
       </Flex>
     </Box>

--- a/frontend/src/components/pages/EditAccountPage.tsx
+++ b/frontend/src/components/pages/EditAccountPage.tsx
@@ -10,13 +10,19 @@ import {
   LANGUAGES,
 } from "../../types/api/UserType";
 import Loading from "../common/Loading";
-import SignupNavbar from "../common/SignupNavbar";
 import AccountForm, { AccountFormMode } from "../user/AccountForm";
 import ProfilePhotoForm from "../user/ProfilePhotoForm";
 
 import AuthContext from "../../contexts/AuthContext";
 import { Role } from "../../types/AuthTypes";
 import getTitleCaseForOneWord from "../../utils/StringUtils";
+import Navbar from "../common/Navbar";
+import {
+  AdminNavbarTabs,
+  AdminPages,
+  EmployeeNavbarTabs,
+  VolunteerNavbarTabs,
+} from "../../constants/Tabs";
 
 const EMPLOYEE_BY_ID = gql`
   query EmployeeUserById($id: ID!) {
@@ -84,6 +90,7 @@ const UPDATE_VOLUNTEER_USER = gql`
 `;
 const EditAccountPage = (): React.ReactElement => {
   const { authenticatedUser } = useContext(AuthContext);
+  const [userRole] = useState(authenticatedUser?.role);
 
   const [key, setKey] = useState<number>(0); // Used to force a re-render
   const [user, setUser] = useState<
@@ -185,7 +192,17 @@ const EditAccountPage = (): React.ReactElement => {
 
   return (
     <>
-      <SignupNavbar />
+      <Navbar
+        defaultIndex={Number(AdminPages.AdminSchedulePosting)}
+        tabs={
+          // eslint-disable-next-line no-nested-ternary
+          userRole === Role.Admin
+            ? AdminNavbarTabs
+            : userRole === Role.Employee
+            ? EmployeeNavbarTabs
+            : VolunteerNavbarTabs
+        }
+      />
       <Container maxW="container.xl" alignItems="left" mt={12}>
         <Text mb={2} textStyle="display-large">
           Edit Profile


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #573 
Closes #533 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Made logo clickable in the `SignupNavbar.tsx` component
* Customized navbar for `/edit-account` per user type


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to `/edit-account` as multiple roles to see if navbar changes 
2. Go to `/new-account` and check if logo expands + clicks!


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
