### PR TITLE
Update branch mutation query to remove stale signups + unsaved selected branches bug

### DIFF
--- a/backend/services/implementations/branchService.ts
+++ b/backend/services/implementations/branchService.ts
@@ -170,6 +170,20 @@ class BranchService implements IBranchService {
             },
           },
         });
+        await prisma.signup.deleteMany({
+          where: {
+            userId: {
+              equals: userId,
+            },
+            shift: {
+              posting: {
+                branchId: {
+                  notIn: branchIds.map((id) => Number(id)),
+                },
+              },
+            },
+          },
+        });
       }
     } catch (error: unknown) {
       Logger.error(`Failed to get user. Reason = ${getErrorMessage(error)}`);

--- a/frontend/src/components/admin/users/ProfileDrawer.tsx
+++ b/frontend/src/components/admin/users/ProfileDrawer.tsx
@@ -42,6 +42,7 @@ type ProfileDrawerProps = {
   branches: BranchResponseDTO[];
   selectedBranches: BranchResponseDTO[];
   handleBranchMenuItemClicked: (item: BranchResponseDTO) => void;
+  resetSelectedBranches: () => void;
 };
 
 const DELETE_VOLUNTEER_USER_BY_EMAIL = gql`
@@ -74,6 +75,7 @@ const ProfileDrawer = ({
   branches,
   selectedBranches,
   handleBranchMenuItemClicked,
+  resetSelectedBranches,
 }: ProfileDrawerProps): React.ReactElement => {
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
   const [deleteUserByEmail] = useMutation(
@@ -95,7 +97,15 @@ const ProfileDrawer = ({
   };
 
   return (
-    <Drawer isOpen={isOpen} placement="right" onClose={onClose} size="sm">
+    <Drawer
+      isOpen={isOpen}
+      placement="right"
+      onClose={() => {
+        resetSelectedBranches();
+        onClose();
+      }}
+      size="sm"
+    >
       <DrawerOverlay />
       <DrawerContent>
         <DrawerBody p={0}>
@@ -128,6 +138,7 @@ const ProfileDrawer = ({
             )}
             <Box mx="6">
               <MultiBranchSelector
+                isVolunteer={isVolunteer}
                 userEmail={email}
                 branches={branches}
                 selectedBranches={selectedBranches}

--- a/frontend/src/components/admin/users/UserManagementTableProfileCell.tsx
+++ b/frontend/src/components/admin/users/UserManagementTableProfileCell.tsx
@@ -53,6 +53,10 @@ const UserManagementTableProfileCell = ({
     }
   };
 
+  const resetSelectedBranches = () => {
+    setSelectedBranches(userBranches);
+  };
+
   return (
     <>
       <Tooltip label="View details" placement="bottom-start">
@@ -84,6 +88,7 @@ const UserManagementTableProfileCell = ({
         branches={branches}
         selectedBranches={selectedBranches}
         handleBranchMenuItemClicked={handleBranchMenuItemClicked}
+        resetSelectedBranches={resetSelectedBranches}
       />
     </>
   );

--- a/frontend/src/components/pages/admin/user/MultiBranchSelector.tsx
+++ b/frontend/src/components/pages/admin/user/MultiBranchSelector.tsx
@@ -11,17 +11,20 @@ import {
   MenuOptionGroup,
   MenuItemOption,
   useToast,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import { gql, useMutation } from "@apollo/client";
 import colors from "../../../../theme/colors";
 import { BranchResponseDTO } from "../../../../types/api/BranchTypes";
+import DeleteModal from "../../../admin/DeleteModal";
 
 type MultiBranchSelectorProps = {
   userEmail: string;
   branches: BranchResponseDTO[];
   selectedBranches: BranchResponseDTO[];
   handleBranchMenuItemClicked: (item: BranchResponseDTO) => void;
+  isVolunteer?: boolean;
 };
 
 const UPDATE_USER_BRANCHES = gql`
@@ -38,8 +41,10 @@ const MultiBranchSelector = ({
   branches,
   selectedBranches,
   handleBranchMenuItemClicked,
+  isVolunteer,
 }: MultiBranchSelectorProps): React.ReactElement => {
   const toast = useToast();
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const [isEditingBranches, setIsEditingBranches] = useState(false);
 
   const [updateUserBranches] = useMutation(UPDATE_USER_BRANCHES, {
@@ -47,6 +52,7 @@ const MultiBranchSelector = ({
       email: userEmail,
       branchIds: selectedBranches.map((branch) => branch.id),
     },
+    refetchQueries: ["AdminUserManagementPage_Users"],
   });
 
   const handleEditSaveButtonClicked = async () => {
@@ -67,76 +73,86 @@ const MultiBranchSelector = ({
   };
 
   return (
-    <Box>
-      <Flex justifyContent="space-between" alignItems="center">
-        <Text fontWeight="bold">Branches</Text>
-        {isEditingBranches ? (
-          <Button
-            variant="outline"
-            onClick={handleEditSaveButtonClicked}
-            py="1"
-          >
-            Save
-          </Button>
-        ) : (
-          <Button
-            variant="outline"
-            onClick={handleEditSaveButtonClicked}
-            py="1"
-          >
-            Edit
-          </Button>
-        )}
-      </Flex>
-      <Flex mt={5} flexWrap="wrap">
-        {isEditingBranches ? (
-          <Menu closeOnSelect={false}>
-            <MenuButton
-              as={Button}
-              backgroundColor={colors.background.white}
-              color={colors.text.default}
-              borderRadius="md"
-              borderWidth="1px"
-              rightIcon={<ChevronDownIcon />}
-              width="100%"
-              textAlign="left"
-              _hover={{ bg: colors.background.white }}
-              _active={{ bg: colors.background.white }}
+    <>
+      <DeleteModal
+        body="Volunteer sign ups for removed branches will be permanently deleted."
+        title="Update this volunteer's branches?"
+        confirmText="Confirm"
+        isOpen={isOpen}
+        onClose={onClose}
+        onDelete={handleEditSaveButtonClicked}
+      />
+      <Box>
+        <Flex justifyContent="space-between" alignItems="center">
+          <Text fontWeight="bold">Branches</Text>
+          {isEditingBranches ? (
+            <Button
+              variant="outline"
+              onClick={isVolunteer ? onOpen : handleEditSaveButtonClicked}
+              py="1"
             >
-              {selectedBranches.length}{" "}
-              {selectedBranches.length === 1 ? "branch" : "branches"}
-            </MenuButton>
-            <MenuList>
-              <MenuOptionGroup
-                title="Branch Access"
-                type="checkbox"
-                value={selectedBranches.map((branch) => branch.id)}
+              Save
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              onClick={handleEditSaveButtonClicked}
+              py="1"
+            >
+              Edit
+            </Button>
+          )}
+        </Flex>
+        <Flex mt={5} flexWrap="wrap">
+          {isEditingBranches ? (
+            <Menu closeOnSelect={false}>
+              <MenuButton
+                as={Button}
+                backgroundColor={colors.background.white}
+                color={colors.text.default}
+                borderRadius="md"
+                borderWidth="1px"
+                rightIcon={<ChevronDownIcon />}
+                width="100%"
+                textAlign="left"
+                _hover={{ bg: colors.background.white }}
+                _active={{ bg: colors.background.white }}
               >
-                {branches.map((branch) => {
-                  return (
-                    <MenuItemOption
-                      key={branch.id}
-                      value={branch.id}
-                      onClick={() => handleBranchMenuItemClicked(branch)}
-                    >
-                      {branch.name}
-                    </MenuItemOption>
-                  );
-                })}
-              </MenuOptionGroup>
-            </MenuList>
-          </Menu>
-        ) : (
-          selectedBranches.map((branch) => {
-            return (
-              <Tag key={branch.id} size="md" height="32px" mr={4} mb={2}>
-                {branch.name}
-              </Tag>
-            );
-          })
-        )}
-      </Flex>
-    </Box>
+                {selectedBranches.length}{" "}
+                {selectedBranches.length === 1 ? "branch" : "branches"}
+              </MenuButton>
+              <MenuList>
+                <MenuOptionGroup
+                  title="Branch Access"
+                  type="checkbox"
+                  value={selectedBranches.map((branch) => branch.id)}
+                >
+                  {branches.map((branch) => {
+                    return (
+                      <MenuItemOption
+                        key={branch.id}
+                        value={branch.id}
+                        onClick={() => handleBranchMenuItemClicked(branch)}
+                      >
+                        {branch.name}
+                      </MenuItemOption>
+                    );
+                  })}
+                </MenuOptionGroup>
+              </MenuList>
+            </Menu>
+          ) : (
+            selectedBranches.map((branch) => {
+              return (
+                <Tag key={branch.id} size="md" height="32px" mr={4} mb={2}>
+                  {branch.name}
+                </Tag>
+              );
+            })
+          )}
+        </Flex>
+      </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #569


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated updateUserBranchByEmail mutation such that it deletes stale signups when a volunteer has been removed from the branch
* Fix bug where selected branch state is in consistent when discarding branch edits on user management profile drawer at `admin/users` by resetting selected branches to user branches on closing drawer


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. got to `admin/users`, when saving volunteer branches on the profile drawer, a new modal appears for the destructive action
2. when removing a branch from user, ensure that all signups for that user regardless of status has been removed
3. If you discard your branch edits the state is now consistent when revisiting the profile drawer

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness
* Look and feel

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
