### PR TITLE
Add unavailable shifts tab to volunteer shifts table

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/MonthlyViewReadOnlyShiftCalendar.tsx
@@ -94,7 +94,6 @@ const MonthlyViewShiftCalendar = ({
         dayMaxEvents={3}
         displayEventEnd
         dayCellClassNames={(day: DayCellContentArg) => applyCellClasses(day)}
-        editable
         dateClick={({ date }) => onDayClick(date)}
         eventClick={onEventClick}
         eventColor={colors.violet}

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -172,7 +172,7 @@ const OrgWideCalendar = (): React.ReactElement => {
               .map((posting) => posting.id)
               .includes(shift.postingId) &&
             shift.signups.length > 0 &&
-            shift.signups[0].status === "PUBLISHED",
+            shift.signups.some((signup) => signup.status === "PUBLISHED"),
         );
         setShifts(scheduledShifts);
         if (shiftsData.length) {

--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -104,6 +104,7 @@ const POSTING = gql`
       startDate
       endDate
       status
+      autoClosingDate
     }
   }
 `;

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -24,17 +24,17 @@ type VolunteerShiftsTableProps = {
 
 const UPCOMING_SHIFTS = 0;
 const PENDING_SHIFTS = 1;
-const UNAVAILABLE_SHIFTS = 2;
+const FILLED_SHIFTS = 2;
 
 const VolunteerShiftsTableContent = ({
   upcomingShifts,
   pendingShifts,
-  unavailableShifts,
+  filledShifts,
   tabIndex,
 }: {
   upcomingShifts: ShiftSignupPostingResponseDTO[];
   pendingShifts: ShiftSignupPostingResponseDTO[];
-  unavailableShifts: ShiftSignupPostingResponseDTO[];
+  filledShifts: ShiftSignupPostingResponseDTO[];
   tabIndex: number;
 }): React.ReactElement => {
   if (tabIndex === UPCOMING_SHIFTS && upcomingShifts.length > 0) {
@@ -66,8 +66,8 @@ const VolunteerShiftsTableContent = ({
       </Table>
     );
   }
-  if (tabIndex === UNAVAILABLE_SHIFTS && unavailableShifts.length > 0) {
-    return <VolunteerUpcomingShiftsTable shifts={unavailableShifts} />;
+  if (tabIndex === FILLED_SHIFTS && filledShifts.length > 0) {
+    return <VolunteerUpcomingShiftsTable shifts={filledShifts} />;
   }
   return <VolunteerShiftsTableEmptyState />;
 };
@@ -89,9 +89,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
 
   const pendingShifts = shifts
     .filter(
-      (shift) =>
-        (shift.status === "PENDING" || shift.status === "CONFIRMED") &&
-        moment(shift.autoClosingDate, "YYYY-MM-DD").isSameOrAfter(),
+      (shift) => shift.status === "PENDING" || shift.status === "CONFIRMED",
     )
     .filter((shift) => {
       if (filter === "all") {
@@ -100,12 +98,8 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       return moment().isSame(moment(shift.autoClosingDate), filter);
     });
 
-  const unavailableShifts = shifts
-    .filter(
-      (shift) =>
-        (shift.status === "PENDING" || shift.status === "CONFIRMED") &&
-        moment(shift.autoClosingDate, "YYYY-MM-DD").isBefore(),
-    )
+  const filledShifts = shifts
+    .filter((shift) => shift.status === "CANCELED")
     .filter((shift) => {
       if (filter === "all") {
         return true;
@@ -136,7 +130,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
           <TabList borderBottom="none">
             <Tab>Upcoming Shifts</Tab>
             <Tab>Requests Pending Confirmation</Tab>
-            <Tab>Unavailable Shifts</Tab>
+            <Tab>Filled Shifts</Tab>
           </TabList>
         </Tabs>
         <HStack>
@@ -155,7 +149,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
       <VolunteerShiftsTableContent
         upcomingShifts={upcomingShifts}
         pendingShifts={pendingShifts}
-        unavailableShifts={unavailableShifts}
+        filledShifts={filledShifts}
         tabIndex={tabIndex}
       />
     </Box>

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -124,13 +124,6 @@ const customTheme = extendTheme(
               borderColor: "background.dark",
               borderCollapse: "collapse",
             },
-            tr: {
-              _last: {
-                td: {
-                  borderBottom: "none",
-                },
-              },
-            },
             caption: {
               borderTop: "2px",
               borderColor: "background.dark",


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #537 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added an unavailable shifts tab to the volunteer shifts table. A shift is unavailable if the super admin published the schedule and volunteer was not selected for that shift.
* Fixed some bugs on OrgWideCalendar & schedule creation toast
* Fixed table UI for volunteer shifts table


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create some cancelled shifts w/ prisma studio
2. Test that these shifts are correctly displayed in the filled shifts tab


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Functionality


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
