### PR TITLE
Change textbox width

### DIFF
--- a/frontend/src/components/common/RichText/RichTextField.tsx
+++ b/frontend/src/components/common/RichText/RichTextField.tsx
@@ -406,7 +406,7 @@ const RichTextField: FunctionComponent<RichTextFieldProps> = (
         borderRadius="sm"
         borderColor={editorBorderColor}
         p="5px"
-        maxW="container.md"
+        maxW="100%"
         sx={{
           ...fontSizeObject,
           ".public-DraftEditorPlaceholder-root": {


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #565


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed width of the textbox container from `container.md` to `100%`.
![image](https://user-images.githubusercontent.com/30396273/184747402-5952be5c-7359-4897-be7d-3de2d3538720.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login as an admin (sistering+admin@uwblueprint.org works) and create a posting, verifying that the Role Description text box extends the entire way like the Figma design: 
![image](https://user-images.githubusercontent.com/30396273/184746435-8df43221-7da3-4735-85be-b32de67f7a23.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* We could pass width in as a prop for different uses but I don't think it's necessary, this is the only place we use the `RichTextField` component.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR