### PR TITLE
Add branch tags to edit profile page

### DIFF
--- a/frontend/src/components/pages/EditAccountPage.tsx
+++ b/frontend/src/components/pages/EditAccountPage.tsx
@@ -237,10 +237,10 @@ const EditAccountPage = (): React.ReactElement => {
             isAdmin={authenticatedUser?.role !== Role.Volunteer}
             firstName={user.firstName}
             lastName={user.lastName}
-            email={user?.email}
+            email={user.email}
             dateOfBirth={
               user.dateOfBirth
-                ? moment(user?.dateOfBirth).format("YYYY-MM-DD")
+                ? moment(user.dateOfBirth).format("YYYY-MM-DD")
                 : ""
             }
             pronouns={user.pronouns}

--- a/frontend/src/components/pages/EditAccountPage.tsx
+++ b/frontend/src/components/pages/EditAccountPage.tsx
@@ -1,5 +1,13 @@
 import { gql, useMutation, useQuery } from "@apollo/client";
-import { Container, Divider, Text, useToast } from "@chakra-ui/react";
+import {
+  Container,
+  Divider,
+  HStack,
+  Tag,
+  TagLabel,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
 import moment from "moment";
 import {
@@ -189,6 +197,8 @@ const EditAccountPage = (): React.ReactElement => {
     }
   };
 
+  console.log(user);
+
   return (
     <>
       <Navbar
@@ -207,26 +217,45 @@ const EditAccountPage = (): React.ReactElement => {
           Edit Profile
         </Text>
         <ProfilePhotoForm />
-        <Divider my={8} />
+        {user && (
+          <HStack mt={6}>
+            {user.branches.map((branch) => (
+              <Tag
+                size="lg"
+                key="lg"
+                borderRadius="full"
+                variant="brand"
+                colorScheme="red"
+              >
+                <TagLabel>{branch.name}</TagLabel>
+              </Tag>
+            ))}
+          </HStack>
+        )}
+        <Divider my={6} />
         {user && (
           <AccountForm
             key={key}
             mode={AccountFormMode.EDIT}
             isAdmin={authenticatedUser?.role !== Role.Volunteer}
-            firstName={user?.firstName}
-            lastName={user?.lastName}
+            firstName={user.firstName}
+            lastName={user.lastName}
             email={user?.email}
-            dateOfBirth={moment(user?.dateOfBirth).format("YYYY-MM-DD")}
-            pronouns={user?.pronouns}
-            phoneNumber={user?.phoneNumber}
-            emergencyNumber={user?.emergencyContactPhone}
-            emergencyEmail={user?.emergencyContactEmail}
-            emergencyName={user?.emergencyContactName}
-            prevLanguages={user?.languages?.map((language) => ({
+            dateOfBirth={
+              user.dateOfBirth
+                ? moment(user?.dateOfBirth).format("YYYY-MM-DD")
+                : ""
+            }
+            pronouns={user.pronouns}
+            phoneNumber={user.phoneNumber}
+            emergencyNumber={user.emergencyContactPhone}
+            emergencyEmail={user.emergencyContactEmail}
+            emergencyName={user.emergencyContactName}
+            prevLanguages={user.languages.map((language) => ({
               id: String(LANGUAGES.indexOf(language) + 1),
               name: getTitleCaseForOneWord(language),
             }))}
-            prevSkills={user?.skills}
+            prevSkills={user.skills}
             onEmployeeEdit={onEmployeeEdit}
             onVolunteerEdit={onVolunteerEdit}
           />

--- a/frontend/src/components/pages/EditAccountPage.tsx
+++ b/frontend/src/components/pages/EditAccountPage.tsx
@@ -197,8 +197,6 @@ const EditAccountPage = (): React.ReactElement => {
     }
   };
 
-  console.log(user);
-
   return (
     <>
       <Navbar
@@ -221,11 +219,10 @@ const EditAccountPage = (): React.ReactElement => {
           <HStack mt={6}>
             {user.branches.map((branch) => (
               <Tag
+                key={branch.id}
                 size="lg"
-                key="lg"
                 borderRadius="full"
                 variant="brand"
-                colorScheme="red"
               >
                 <TagLabel>{branch.name}</TagLabel>
               </Tag>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #599 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added user branch tags to the edit profile page
* Fixed existing React warning with invalid date format


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to `http://localhost:3000/edit-account`, the user's branches should show at the top:
<img width="1440" alt="Screen Shot 2022-08-16 at 12 07 12 AM" src="https://user-images.githubusercontent.com/47638847/184796011-a95db0d6-2fd9-477a-ae18-7f2419371fbf.png">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
