### PR TITLE
Update getShiftSignupForUser to only return signups for current postings

### DIFF
--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -26,7 +26,10 @@ import {
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import IShiftService from "../interfaces/shiftService";
-import { getInterval } from "../../utilities/dateUtils";
+import {
+  getInterval,
+  getTodayForTZIgnoredUTC,
+} from "../../utilities/dateUtils";
 
 const prisma = new PrismaClient();
 
@@ -61,7 +64,7 @@ type EnumPostingStatusFilter = {
 };
 
 type DateTimeFilter = {
-  gt?: Date;
+  gte?: Date;
 };
 
 type PostingWhereInput = {
@@ -251,7 +254,11 @@ class PostingService implements IPostingService {
     return prisma.$transaction(async (prismaClient) => {
       const filter: PostingWhereInput[] = [];
       if (closingDate !== undefined) {
-        filter.push({ autoClosingDate: { gt: closingDate } });
+        filter.push({
+          autoClosingDate: {
+            gte: getTodayForTZIgnoredUTC(closingDate),
+          },
+        });
       }
       if (statuses !== undefined) {
         filter.push({ status: { in: statuses } });

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -9,6 +9,7 @@ import {
 } from "../../types";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
+import { getTodayForTZIgnoredUTC } from "../../utilities/dateUtils";
 
 const prisma = new PrismaClient();
 
@@ -39,6 +40,15 @@ class ShiftSignupService implements IShiftSignupService {
           {
             userId: Number(userId),
           },
+          {
+            shift: {
+              posting: {
+                endDate: {
+                  gte: getTodayForTZIgnoredUTC(),
+                },
+              },
+            },
+          },
           signupStatus
             ? {
                 status: signupStatus,
@@ -47,18 +57,7 @@ class ShiftSignupService implements IShiftSignupService {
         ],
       };
       const shiftSignups = await prisma.signup.findMany({
-        where: {
-          AND: [
-            filter,
-            {
-              shift: {
-                posting: {
-                  endDate: { gt: new Date() },
-                },
-              },
-            },
-          ],
-        },
+        where: filter,
         include: {
           shift: {
             include: {

--- a/backend/services/implementations/shiftSignupService.ts
+++ b/backend/services/implementations/shiftSignupService.ts
@@ -47,7 +47,18 @@ class ShiftSignupService implements IShiftSignupService {
         ],
       };
       const shiftSignups = await prisma.signup.findMany({
-        where: filter,
+        where: {
+          AND: [
+            filter,
+            {
+              shift: {
+                posting: {
+                  endDate: { gt: new Date() },
+                },
+              },
+            },
+          ],
+        },
         include: {
           shift: {
             include: {

--- a/backend/utilities/dateUtils.ts
+++ b/backend/utilities/dateUtils.ts
@@ -1,6 +1,9 @@
 import moment from "moment";
 import { RecurrenceInterval } from "../types";
 
+const UTC_EDT_OFFSET_HOURS = 4;
+const UTC_EST_OFFSET_HOURS = 5;
+
 export const addDays = (date: Date, daysToAdd: number): Date => {
   return new Date(new Date().setDate(date.getDate() + daysToAdd));
 };
@@ -30,4 +33,14 @@ export const getInterval = (recurrence: RecurrenceInterval): number => {
     default:
       throw new Error(`Invalid recurrence ${recurrence}`);
   }
+};
+
+export const getTodayForTZIgnoredUTC = (date: Date = new Date()): Date => {
+  return moment(date)
+    .subtract(
+      moment().isDST() ? UTC_EDT_OFFSET_HOURS : UTC_EST_OFFSET_HOURS,
+      "hours",
+    )
+    .startOf("day")
+    .toDate();
 };


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #604 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Update getShiftSignupsForUser query to only query for signups for postings that have not ended yet. We do not have any usage of this query that needs expired signups.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Do this locally where you have direct access to change the DB records
2. Login as a volunteer
3. Sign up for 3 signups
4. Go to DB and put signup for PUBLISHED, CANCELLED, and PENDING, one for each. They should appear in volunteer homepage signups tab
5. GO to DB and put posting endate to a date in the past
6. The signups for volunteer should no longer be visible
7. Similarly they should not be visible on schedule review page - volunteer profile page


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
