### PR TITLE
Set unselected signups to cancelled on posting publish

### DIFF
--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -151,10 +151,7 @@ const checkHasConfirmedSignup = (
 ): boolean => {
   for (let i = 0; i < shifts.length; i += 1) {
     for (let j = 0; j < shifts[i].signups.length; j += 1) {
-      if (
-        shifts[i].signups[j].status === "CONFIRMED" ||
-        shifts[i].signups[j].status === "PUBLISHED"
-      ) {
+      if (shifts[i].signups[j].status in ["CONFIRMED", "PUBLISHED"]) {
         return true;
       }
     }

--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -343,11 +343,11 @@ const SchedulePostingPage = (): React.ReactElement => {
 
   const handleOnPublishClick = async () => {
     const shiftsCopy = cloneDeep(shifts);
-    const publishedSignups: UpsertSignupDTO[] = [];
+    const upsertSignups: UpsertSignupDTO[] = [];
     shiftsCopy.forEach((shift, shiftIndex) =>
       shift.signups.forEach((signup, signupIndex) => {
         if (signup.status === "CONFIRMED") {
-          publishedSignups.push({
+          upsertSignups.push({
             shiftId: shift.id,
             userId: signup.volunteer.id,
             status: "PUBLISHED",
@@ -355,15 +355,24 @@ const SchedulePostingPage = (): React.ReactElement => {
             note: signup.note,
           });
           shiftsCopy[shiftIndex].signups[signupIndex].status = "PUBLISHED";
+        } else if (signup.status === "PENDING") {
+          upsertSignups.push({
+            shiftId: shift.id,
+            userId: signup.volunteer.id,
+            status: "CANCELED",
+            numVolunteers: signup.numVolunteers,
+            note: signup.note,
+          });
+          shiftsCopy[shiftIndex].signups[signupIndex].status = "CANCELED";
         }
       }),
     );
 
-    if (publishedSignups.length) {
+    if (upsertSignups.length) {
       const response = await submitSignups({
         variables: {
           upsertDeleteShifts: {
-            upsertShiftSignups: publishedSignups,
+            upsertShiftSignups: upsertSignups,
             deleteShiftSignups: [],
           },
         },


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #603 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added condition in `handleOnPublishClick()` method in `SchedulePostingPage.tsx` to also set `PENDING` signups to `CANCELED`. 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. As a volunteer, signup for a posting
2. As an admin, review signups for that posting and do not check the volunteer signup
3. Publish the posting
4. Check that the volunteer signup was cancelled


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
