### PR TITLE
Fix timezone bug in VolunteerPendingShiftsTableRow

### DIFF
--- a/frontend/src/utils/DateTimeUtils.ts
+++ b/frontend/src/utils/DateTimeUtils.ts
@@ -60,7 +60,7 @@ export const formatDateStringYearAbbrWeekday = (
  */
 export const formatDateMonthDay = (dateStringInput: string): string => {
   const inputAsDate = new Date(dateStringInput);
-  return moment(inputAsDate).format("dddd, MMM D");
+  return moment(inputAsDate).utc().format("dddd, MMM D");
 };
 
 /**


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
N/A - quick fix for this issue:
<img width="1875" alt="Capture" src="https://user-images.githubusercontent.com/30205929/185762816-60601fa7-358d-42a5-af42-ef955b591f7e.PNG">




<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Interpret date in UTC instead of local time in `formatDateMonthDay` util function used in `VolunteerPendingShiftsTableRow`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login as a volunteer who has pending shifts
2. Verify that the displayed deadline date of the pending shift's associated posting matches what is returned by the backend
<img width="1897" alt="Capture1" src="https://user-images.githubusercontent.com/30205929/185762851-aed38835-b553-4d08-adc8-24761a67d88e.PNG">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
