### PR TITLE
Reword Volunteer Shifts Tab to be Less Vague + UI underflow

### DIFF
--- a/frontend/src/components/admin/BranchManagerTable.tsx
+++ b/frontend/src/components/admin/BranchManagerTable.tsx
@@ -137,7 +137,10 @@ const BranchManagerTable = ({
           <Table variant="brand">
             <Tbody>
               {branches.map((branch) => (
-                <Tr key={Number(branch.id)}>
+                <Tr
+                  key={Number(branch.id)}
+                  _last={{ td: { borderBottom: "none" } }}
+                >
                   <Td>
                     <Tag>{branch.name}</Tag>
                   </Td>

--- a/frontend/src/components/admin/LanguageManagerTable.tsx
+++ b/frontend/src/components/admin/LanguageManagerTable.tsx
@@ -131,7 +131,10 @@ const LanguageManagerTable = ({
           <Table variant="brand">
             <Tbody>
               {languages.map((language) => (
-                <Tr key={Number(language.id)}>
+                <Tr
+                  key={Number(language.id)}
+                  _last={{ td: { borderBottom: "none" } }}
+                >
                   <Td>
                     <Tag variant="brand">{language.name}</Tag>
                   </Td>

--- a/frontend/src/components/admin/SkillsManagerTable.tsx
+++ b/frontend/src/components/admin/SkillsManagerTable.tsx
@@ -127,7 +127,10 @@ const SkillsManagerTable = ({
           <Table variant="brand">
             <Tbody>
               {skills.map((skill) => (
-                <Tr key={Number(skill.id)}>
+                <Tr
+                  key={Number(skill.id)}
+                  _last={{ td: { borderBottom: "none" } }}
+                >
                   <Td>
                     <Tag variant="brand">{skill.name}</Tag>
                   </Td>

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -77,7 +77,7 @@ const Login = (): React.ReactElement => {
   return (
     <Box>
       <AuthNavbar />
-      <Box width="100%" display="flex" flexDirection="row" height="100vh">
+      <Box width="100%" display="flex" flexDirection="row" minH="100vh">
         <Box backgroundColor="background.white" flexGrow={4}>
           <Box maxWidth="480px" mt="8vh" mx="auto">
             <Image src={logo} alt="Sistering logo" h={32} />

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -40,7 +40,7 @@ const ResetPassword = (): React.ReactElement => {
   return (
     <Box>
       <AuthNavbar />
-      <Box width="100%" display="flex" flexDirection="row" height="100vh">
+      <Box width="100%" display="flex" flexDirection="row" minH="100vh">
         <Box backgroundColor="background.white" flexGrow={4}>
           <Box maxWidth="480px" mt="8vh" mx="auto">
             <Image src={logo} alt="Sistering logo" h={32} />

--- a/frontend/src/components/common/Loading.tsx
+++ b/frontend/src/components/common/Loading.tsx
@@ -3,7 +3,7 @@ import { Box, Center, Spinner, Text } from "@chakra-ui/react";
 
 const Loading: React.FC = () => {
   return (
-    <Center h="100vh">
+    <Center minH="100vh">
       <Box textAlign="center">
         <Spinner
           thickness="6px"

--- a/frontend/src/components/pages/AccountCreatedPage.tsx
+++ b/frontend/src/components/pages/AccountCreatedPage.tsx
@@ -6,7 +6,7 @@ import Sistering_Logo from "../../assets/Sistering_Logo.svg";
 const AccountCreatedPage = (): React.ReactElement => {
   const history = useHistory();
   return (
-    <Flex align="center" height="100vh">
+    <Flex align="center" minH="100vh">
       <VStack align="center" width="100vw">
         <Image src={Sistering_Logo} alt="Sistering logo" />
         <Text fontSize="xl" fontWeight="bold" mt="20px">

--- a/frontend/src/components/pages/CreateAccountPage.tsx
+++ b/frontend/src/components/pages/CreateAccountPage.tsx
@@ -10,7 +10,7 @@ const CreateAccountPage = (): React.ReactElement => {
   const token = queryParams.get("token");
 
   return (
-    <Box width="100%" display="flex" flexDirection="row" height="100vh">
+    <Box width="100%" display="flex" flexDirection="row" minH="100vh">
       <Box backgroundColor="background.white" flexGrow={4}>
         <Box maxWidth="480px" mt="8vh" mx="auto">
           <Image src={Sistering_Logo} alt="Sistering logo" h={32} />

--- a/frontend/src/components/pages/NotFound.tsx
+++ b/frontend/src/components/pages/NotFound.tsx
@@ -10,7 +10,7 @@ const NotFound = (): React.ReactElement => {
   return (
     <Flex
       mx="auto"
-      h="100vh"
+      minH="100vh"
       direction="column"
       align="center"
       justify="center"

--- a/frontend/src/components/pages/admin/AdminHomepage.tsx
+++ b/frontend/src/components/pages/admin/AdminHomepage.tsx
@@ -225,7 +225,7 @@ const AdminHomepage = (): React.ReactElement => {
   return (
     <>
       {error && <ErrorModal />}
-      <Flex flexFlow="column" width="100%" height="100vh">
+      <Flex flexFlow="column" width="100%" minH="100vh">
         <Navbar
           defaultIndex={Number(AdminPages.AdminSchedulePosting)}
           tabs={isSuperAdmin ? AdminNavbarTabs : EmployeeNavbarTabs}

--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -434,7 +434,7 @@ const SchedulePostingPage = (): React.ReactElement => {
   }
 
   return (
-    <Flex flexFlow="column" width="100%" height="100vh">
+    <Flex flexFlow="column" width="100%" minH="100vh">
       {(tableDataQueryError || postingError) && <ErrorModal />}
       <Navbar
         defaultIndex={Number(AdminPages.AdminSchedulePosting)}

--- a/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
+++ b/frontend/src/components/pages/admin/user/AdminUserManagementPage.tsx
@@ -433,7 +433,7 @@ const AdminUserManagementPage = (): React.ReactElement => {
         }}
         handleBranchMenuItemClicked={handleMultiUserBranchMenuItemClicked}
       />
-      <Flex flexFlow="column" width="100%" height="100vh">
+      <Flex flexFlow="column" width="100%" minH="100vh">
         <Navbar
           defaultIndex={Number(AdminPages.AdminUserManagement)}
           tabs={AdminNavbarTabs}

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -138,13 +138,7 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         defaultIndex={VolunteerPages.VolunteerPostings}
         tabs={VolunteerNavbarTabs}
       />
-      <Box
-        bg="background.light"
-        pt="48px"
-        px="101px"
-        pb="64px"
-        minHeight="100vh"
-      >
+      <Box bg="background.light" pt="48px" px="101px" pb="64px" minH="100vh">
         <Box maxW="1280px" mx="auto">
           <HStack justify="space-between" pb="24px">
             <Text textStyle="display-small-semibold">Events</Text>

--- a/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
+++ b/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
@@ -52,7 +52,7 @@ const VolunteerShiftsPage = (): React.ReactElement => {
   });
 
   return (
-    <Flex h="100vh" flexFlow="column" bg="background.light">
+    <Flex minH="100vh" flexFlow="column" bg="background.light">
       {error && <ErrorModal />}
       <Navbar
         defaultIndex={VolunteerPages.VolunteerShifts}

--- a/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
+++ b/frontend/src/components/pages/volunteer/shift/VolunteerShiftsPage.tsx
@@ -52,13 +52,13 @@ const VolunteerShiftsPage = (): React.ReactElement => {
   });
 
   return (
-    <Flex h="100vh" flexFlow="column">
+    <Flex h="100vh" flexFlow="column" bg="background.light">
       {error && <ErrorModal />}
       <Navbar
         defaultIndex={VolunteerPages.VolunteerShifts}
         tabs={VolunteerNavbarTabs}
       />
-      <Box bg="background.light" p={10}>
+      <Box p={10}>
         <Container
           maxW="container.xl"
           backgroundColor="background.white"

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTable.tsx
@@ -129,7 +129,7 @@ const VolunteerShiftsTable: React.FC<VolunteerShiftsTableProps> = ({
         <Tabs pt={8} onChange={(index) => setTabIndex(index)}>
           <TabList borderBottom="none">
             <Tab>Upcoming Shifts</Tab>
-            <Tab>Requests Pending Confirmation</Tab>
+            <Tab>Pending Shifts</Tab>
             <Tab>Filled Shifts</Tab>
           </TabList>
         </Tabs>

--- a/frontend/src/components/volunteer/shifts/VolunteerShiftsTableEmptyState.tsx
+++ b/frontend/src/components/volunteer/shifts/VolunteerShiftsTableEmptyState.tsx
@@ -18,8 +18,8 @@ const VolunteerShiftsTableEmptyState = (): React.ReactElement => {
     <Table variant="brand">
       <Tbody>
         <Tr>
-          <Td>
-            <Container maxW="container.xl" minH="75vh">
+          <Td borderBottom="none">
+            <Container maxW="container.xl">
               <VStack pt="25%">
                 <Text color="text.gray">No shifts to show</Text>
                 <Button


### PR DESCRIPTION
…on settings manager tables

## Ticket link
<!-- Please replace with your issue number -->
Closes #625 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Reworded pending shifts tab from `Requests Pending Confirmation` to `Pending Shifts`
* Fixed shifts table heights to be consistent and background colour of volunteer shifts page to remain `background.light`
* Fixed bottomBorder of last row in settings manager table to be none


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `http://localhost:3000/volunteer/shifts`
2. Check that table name was reworded
3. Signup for a shift, approve or cancel shift, check that table heights are the same across all shift tables


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
