### PR TITLE
Fix create-account page continue link attach to button

### DIFF
--- a/frontend/src/components/pages/CreateAccountPage.tsx
+++ b/frontend/src/components/pages/CreateAccountPage.tsx
@@ -22,15 +22,12 @@ const CreateAccountPage = (): React.ReactElement => {
               Please follow the steps to activate your sistering account. We
               look forward to working with you.
             </Text>
-            <Button color="violet" width="100%">
-              <Text
-                color="background.white"
-                onClick={() =>
-                  history.push(`${NEW_ACCOUNT_PAGE}?token=${token}`)
-                }
-              >
-                Continue
-              </Text>
+            <Button
+              color="violet"
+              width="100%"
+              onClick={() => history.push(`${NEW_ACCOUNT_PAGE}?token=${token}`)}
+            >
+              <Text color="background.white">Continue</Text>
             </Button>
           </Box>
         </Box>


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #632


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Fixed continue link to be attached to button instead of text on create-account page


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `http://localhost:3000/create-account`
2. Check that the continue button can be clicked without cursor on text


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
