### PR TITLE
Update weekly calendar view to restrict invalid start

### DIFF
--- a/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
+++ b/frontend/src/components/admin/ShiftCalendar/WeekViewShiftCalendar.tsx
@@ -34,6 +34,7 @@ type ShiftCalendarProps = {
   initialDate?: string;
   startDate: string;
   endDate: string;
+  isRecurringEvents?: boolean;
 };
 
 const WeekViewShiftCalendar = ({
@@ -46,6 +47,7 @@ const WeekViewShiftCalendar = ({
   initialDate,
   startDate,
   endDate,
+  isRecurringEvents,
 }: ShiftCalendarProps): React.ReactElement => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
@@ -125,6 +127,10 @@ const WeekViewShiftCalendar = ({
         initialDate={initialDate}
         selectConstraint={{ startTime: "0:00", endTime: "24:00" }}
         validRange={{
+          start:
+            !isRecurringEvents || moment(startDate).isSame(endDate, "week")
+              ? startDate
+              : undefined,
           end: moment(endDate).add(1, "day").format("YYYY-MM-DD"),
         }}
       />

--- a/frontend/src/components/admin/posting/PostingFormShifts.tsx
+++ b/frontend/src/components/admin/posting/PostingFormShifts.tsx
@@ -343,6 +343,7 @@ const PostingFormShifts: React.FC<PostingFormShiftsProps> = ({
           deleteEvent={deleteEvent}
           startDate={startDate}
           endDate={endDate}
+          isRecurringEvents={recurrenceInterval !== "NONE"}
           /* eslint-disable-next-line react/jsx-props-no-spreading */
           {...initialDateProps}
         />


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #614 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Enhancing the logic I removed in https://github.com/uwblueprint/sistering/pull/578/files#diff-1419dbfb9a8576e06b1e14356bb91202a213dcc954255f30c3019d8b0a7a9c96L128
* we should only specify valid start for non-recurring schedules or schedules with start/end date in the same week. This basic guard is sufficient although it does not consider more specific cases like 2 week posting for 1 month recurring event (which actually should have a start guard)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. As a super admin, login and go to create new posting page
2. You should not be able to select shifts on days before the start date (we still allow it for recurring events lasting over than 1 week to allow uneven schedules) 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
