### PR TITLE
Update better toast msg of delete branch failure toast

### DIFF
--- a/frontend/src/components/admin/BranchManagerTable.tsx
+++ b/frontend/src/components/admin/BranchManagerTable.tsx
@@ -94,8 +94,8 @@ const BranchManagerTable = ({
         });
       } catch (error: unknown) {
         toast({
-          title: "Cannot delete branch",
-          description: `${error}`,
+          title: `Cannot delete branch: "${selectedBranch.name}"`,
+          description: `Branch is still referenced by existing postings.`,
           status: "error",
           duration: 9000,
           isClosable: true,


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #575 

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Update toast msg description to be static - usually when a user fails to delete a toast, it is because there are existing postings that is still using the branch, the error tells the user to clear those references before proceeding to delete a branch

![image](https://user-images.githubusercontent.com/44826218/186006727-bb6bc344-e40d-4cdd-85b1-737ef1aa1e1d.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as super admin, try to delete a branch that is used by a toast, you should see the toast error in the screen shot
2. Try creating a new branch and assign yourself to that branch, you should still be able to delete that branch without any error toast

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Any scenarios where this toast error would not make sense - this solution is a tradeoff for simplicity. I can't really see any other internal error scenarios that would cause this issue atm.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
