### PR TITLE
Fix employees can see postings outside of branch

### DIFF
--- a/backend/graphql/resolvers/branchResolvers.ts
+++ b/backend/graphql/resolvers/branchResolvers.ts
@@ -1,8 +1,12 @@
+import { ExpressContext } from "apollo-server-express";
 import BranchService from "../../services/implementations/branchService";
+import UserService from "../../services/implementations/userService";
 import IBranchService from "../../services/interfaces/branchService";
+import IUserService from "../../services/interfaces/userService";
 import { BranchRequestDTO, BranchResponseDTO } from "../../types";
 
-const branchService: IBranchService = new BranchService();
+const userService: IUserService = new UserService();
+const branchService: IBranchService = new BranchService(userService);
 
 const branchResolvers = {
   Query: {
@@ -12,8 +16,12 @@ const branchResolvers = {
     ): Promise<BranchResponseDTO> => {
       return branchService.getBranch(id);
     },
-    branches: async (): Promise<BranchResponseDTO[]> => {
-      return branchService.getBranches();
+    branches: async (
+      _parent: undefined,
+      _args: undefined,
+      context: ExpressContext,
+    ): Promise<BranchResponseDTO[]> => {
+      return branchService.getBranches(context);
     },
   },
   Mutation: {

--- a/backend/graphql/resolvers/postingResolvers.ts
+++ b/backend/graphql/resolvers/postingResolvers.ts
@@ -32,14 +32,13 @@ const postingResolvers = {
       {
         closingDate,
         statuses,
-        userId,
       }: {
         closingDate?: Date;
         statuses?: PostingStatus[];
-        userId?: string;
       } = {},
+      context: ExpressContext,
     ): Promise<PostingResponseDTO[]> => {
-      return postingService.getPostings(closingDate, statuses, userId);
+      return postingService.getPostings(context, closingDate, statuses);
     },
   },
   Mutation: {

--- a/backend/graphql/types/postingType.ts
+++ b/backend/graphql/types/postingType.ts
@@ -64,7 +64,6 @@ const postingType = gql`
     postings(
       closingDate: Date
       statuses: [PostingStatus!]
-      userId: ID
     ): [PostingResponseDTO!]!
   }
 

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -13,6 +13,7 @@ import * as firebaseAdmin from "firebase-admin";
 import { ExpressContext } from "apollo-server-express";
 import { getAccessToken } from "../../middlewares/auth";
 import IPostingService from "../interfaces/postingService";
+import IShiftService from "../interfaces/shiftService";
 import IUserService from "../interfaces/userService";
 import {
   BranchResponseDTO,
@@ -28,10 +29,10 @@ import {
 } from "../../types";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
-import IShiftService from "../interfaces/shiftService";
 import {
   getInterval,
   getTodayForTZIgnoredUTC,
+  isPast,
 } from "../../utilities/dateUtils";
 
 const prisma = new PrismaClient();
@@ -227,7 +228,7 @@ class PostingService implements IPostingService {
         if (
           user.role === Role.EMPLOYEE &&
           !(
-            posting.status === "DRAFT" ||
+            isPast(posting.endDate) ||
             isPostingScheduledBySignups(
               posting.shifts.flatMap((shift) => shift.signups),
             )

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -238,7 +238,7 @@ class PostingService implements IPostingService {
           user.role === Role.VOLUNTEER &&
           (posting.status === "DRAFT" || isPast(posting.endDate))
         ) {
-          throw new Error(`Posting is still in draft or unscheduled.`);
+          throw new Error(`Posting is still in draft or has passed.`);
         }
       }
 

--- a/backend/services/implementations/postingService.ts
+++ b/backend/services/implementations/postingService.ts
@@ -227,12 +227,16 @@ class PostingService implements IPostingService {
         }
         if (
           user.role === Role.EMPLOYEE &&
-          !(
-            isPast(posting.endDate) ||
-            isPostingScheduledBySignups(
+          (posting.status === "DRAFT" ||
+            !isPostingScheduledBySignups(
               posting.shifts.flatMap((shift) => shift.signups),
-            )
-          )
+            ))
+        ) {
+          throw new Error(`Posting is still in draft or unscheduled.`);
+        }
+        if (
+          user.role === Role.VOLUNTEER &&
+          (posting.status === "DRAFT" || isPast(posting.endDate))
         ) {
           throw new Error(`Posting is still in draft or unscheduled.`);
         }

--- a/backend/services/interfaces/branchService.ts
+++ b/backend/services/interfaces/branchService.ts
@@ -1,3 +1,4 @@
+import { ExpressContext } from "apollo-server-express";
 import { BranchRequestDTO, BranchResponseDTO } from "../../types";
 
 interface IBranchService {
@@ -14,7 +15,7 @@ interface IBranchService {
    * @returns array of BranchDTOs
    * @throws Error if branch retrieval fails
    */
-  getBranches(): Promise<BranchResponseDTO[]>;
+  getBranches(context: ExpressContext): Promise<BranchResponseDTO[]>;
 
   /**
    * Create a branch

--- a/backend/services/interfaces/postingService.ts
+++ b/backend/services/interfaces/postingService.ts
@@ -26,9 +26,9 @@ interface IPostingService {
    * @throws Error if posting retrieval fails
    */
   getPostings(
+    context: ExpressContext,
     closingDate?: Date,
     statuses?: PostingStatus[],
-    userId?: string,
   ): Promise<PostingResponseDTO[]>;
 
   /**

--- a/backend/utilities/dateUtils.ts
+++ b/backend/utilities/dateUtils.ts
@@ -46,7 +46,7 @@ export const getTodayForTZIgnoredUTC = (date: Date = new Date()): Date => {
 };
 
 export const isPast = (date: Date): boolean => {
-  return moment(moment(date).utc().format("YYYY-MM-DD")).isBefore(
-    moment(moment().format("YYYY-MM-DD")),
+  return moment(getTodayForTZIgnoredUTC(date)).isBefore(
+    moment(getTodayForTZIgnoredUTC()),
   );
 };

--- a/backend/utilities/dateUtils.ts
+++ b/backend/utilities/dateUtils.ts
@@ -44,3 +44,9 @@ export const getTodayForTZIgnoredUTC = (date: Date = new Date()): Date => {
     .startOf("day")
     .toDate();
 };
+
+export const isPast = (date: Date): boolean => {
+  return moment(moment(date).utc().format("YYYY-MM-DD")).isBefore(
+    moment(moment().format("YYYY-MM-DD")),
+  );
+};

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -61,7 +61,7 @@ const ADMIN_ORG_CALENDAR_TABLE_DATA_QUERY = gql`
 `;
 
 const ADMIN_ORG_CALENDAR_POSTINGS = gql`
-  query AdminOrgCalendarPostings($id: ID!) {
+  query AdminOrgCalendarPostings {
     postings {
       id
       title

--- a/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
+++ b/frontend/src/components/admin/calendar/OrgWideCalendar.tsx
@@ -62,7 +62,7 @@ const ADMIN_ORG_CALENDAR_TABLE_DATA_QUERY = gql`
 
 const ADMIN_ORG_CALENDAR_POSTINGS = gql`
   query AdminOrgCalendarPostings($id: ID!) {
-    postings(userId: $id) {
+    postings {
       id
       title
       branch {
@@ -193,7 +193,6 @@ const OrgWideCalendar = (): React.ReactElement => {
     error: postingsQueryError,
     loading: postingsLoading,
   } = useQuery<AdminOrgCalendarPostings>(ADMIN_ORG_CALENDAR_POSTINGS, {
-    variables: { id: authenticatedUser?.id },
     onCompleted: ({ postings }) => {
       setUserPostings(postings);
       getShiftsAndSignups();

--- a/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
+++ b/frontend/src/components/pages/admin/posting/AdminPostingDetails.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from "react";
+import React from "react";
 import { VStack, Box, Container, Button, Flex } from "@chakra-ui/react";
 
 import { gql, useQuery } from "@apollo/client";
-import { useHistory, useParams } from "react-router-dom";
+import { Redirect, useHistory, useParams } from "react-router-dom";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
-import { PostingResponseDTO } from "../../../../types/api/PostingTypes";
 import PostingDetails from "../../../common/PostingDetails";
 import ErrorModal from "../../../common/ErrorModal";
+import Loading from "../../../common/Loading";
 
 const POSTING = gql`
   query AdminPostingDetails_Posting($id: ID!) {
@@ -36,21 +36,20 @@ const POSTING = gql`
 
 const AdminPostingDetails = (): React.ReactElement => {
   const { id } = useParams<{ id: string }>();
-  const [
-    postingDetails,
-    setPostingDetails,
-  ] = useState<PostingResponseDTO | null>(null);
-  const { error } = useQuery(POSTING, {
+  const {
+    loading: postingLoading,
+    error: postingError,
+    data: { posting: postingDetails } = {},
+  } = useQuery(POSTING, {
     variables: { id },
     fetchPolicy: "cache-and-network",
-    onCompleted: (data) => {
-      setPostingDetails(data.posting);
-    },
   });
   const history = useHistory();
-  return (
+  return (!postingLoading && !postingDetails) || postingError ? (
+    <Redirect to="/not-found" />
+  ) : (
     <Box bg="background.light" py={7} px={10} minH="100vh">
-      {error && <ErrorModal />}
+      {postingError && <ErrorModal />}
       <VStack>
         <Container pt={3} pb={6} px={0} maxW="container.xl">
           <Flex justifyContent="flex-start">
@@ -70,7 +69,11 @@ const AdminPostingDetails = (): React.ReactElement => {
           centerContent
           borderRadius={10}
         >
-          {postingDetails && <PostingDetails postingDetails={postingDetails} />}
+          {postingLoading ? (
+            <Loading />
+          ) : (
+            <PostingDetails postingDetails={postingDetails} />
+          )}
         </Container>
       </VStack>
     </Box>

--- a/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
+++ b/frontend/src/components/pages/admin/schedule/SchedulePostingPage.tsx
@@ -8,7 +8,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import React, { useState, useEffect, useContext } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { Redirect, useHistory, useParams } from "react-router-dom";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import cloneDeep from "lodash.clonedeep";
 
@@ -464,13 +464,15 @@ const SchedulePostingPage = (): React.ReactElement => {
     setHasConfirmedSignup(checkHasConfirmedSignup(shifts));
   }, [shifts]);
 
-  if (postingLoading || postingDetails === undefined) {
+  if (postingLoading) {
     return <Loading />;
   }
 
-  return (
+  return !postingDetails || postingError ? (
+    <Redirect to="/not-found" />
+  ) : (
     <Flex flexFlow="column" width="100%" minH="100vh">
-      {(tableDataQueryError || postingError) && <ErrorModal />}
+      {tableDataQueryError && <ErrorModal />}
       <Navbar
         defaultIndex={Number(AdminPages.AdminSchedulePosting)}
         tabs={isSuperAdmin ? AdminNavbarTabs : EmployeeNavbarTabs}

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingAvailabilities.tsx
@@ -177,11 +177,11 @@ const VolunteerPostingAvailabilities = (): React.ReactElement => {
     }
   };
 
-  return !isPageLoading && !shiftsByPosting ? (
+  return (!isPageLoading && !shiftsByPosting) || postingError ? (
     <Redirect to="/not-found" />
   ) : (
     <Box bg="background.light" pt={14} px={100} minH="100vh">
-      {(shiftError || postingError || hasSubmitError) && <ErrorModal />}
+      {(shiftError || hasSubmitError) && <ErrorModal />}
       <Button
         onClick={() => history.push(`/volunteer/posting/${id}`)}
         variant="link"

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingDetails.tsx
@@ -47,8 +47,8 @@ const VolunteerPostingDetails = (): React.ReactElement => {
   const { id } = useParams<{ id: string }>();
 
   const {
-    loading,
-    error: postingDetailError,
+    loading: postingDetailsLoading,
+    error: postingDetailsError,
     data: { posting: postingDetails } = {},
   } = useQuery(POSTING, {
     variables: { id },
@@ -60,7 +60,7 @@ const VolunteerPostingDetails = (): React.ReactElement => {
     history.push(route);
   };
 
-  return (!loading && !postingDetails) || postingDetailError ? (
+  return (!postingDetailsLoading && !postingDetails) || postingDetailsError ? (
     <Redirect to="/not-found" />
   ) : (
     <Box bg="background.light" py={7} px={10} minH="100vh">
@@ -86,7 +86,7 @@ const VolunteerPostingDetails = (): React.ReactElement => {
           centerContent
           borderRadius={10}
         >
-          {loading ? (
+          {postingDetailsLoading ? (
             <Loading />
           ) : (
             <PostingDetails

--- a/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
+++ b/frontend/src/components/pages/volunteer/posting/VolunteerPostingsPage.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useLayoutEffect, useContext } from "react";
+import React, { useState, useLayoutEffect } from "react";
 import { generatePath, useHistory } from "react-router-dom";
 import { gql, useQuery } from "@apollo/client";
 import { Box, HStack, Select, Text } from "@chakra-ui/react";
-import AuthContext from "../../../../contexts/AuthContext";
 
 import {
   VOLUNTEER_POSTING_AVAILABILITIES,
@@ -36,9 +35,8 @@ const POSTINGS = gql`
   query VolunteerPostingsPage_postings(
     $closingDate: Date!
     $statuses: [PostingStatus!]!
-    $userId: ID!
   ) {
-    postings(closingDate: $closingDate, statuses: $statuses, userId: $userId) {
+    postings(closingDate: $closingDate, statuses: $statuses) {
       id
       branch {
         id
@@ -70,7 +68,6 @@ const VolunteerPostingsPage = (): React.ReactElement => {
     Posting[] | null
   >(null);
   const [filter, setFilter] = useState<FilterType>("week");
-  const { authenticatedUser } = useContext(AuthContext);
 
   const { error } = useQuery(POSTINGS, {
     variables: {
@@ -78,7 +75,6 @@ const VolunteerPostingsPage = (): React.ReactElement => {
         .toISOString()
         .split("T")[0],
       statuses: ["PUBLISHED" as PostingStatus],
-      userId: authenticatedUser?.id,
     },
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #647 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Filter by user branches in `postings` resolver if user is volunteer or employee
  * If employee also only return scheduled or past postings
  * If volunteer also only return unscheduled or scheduled postings
  * Removed old way of doing this for volunteers where we pass an optional userId parameter
* Updated `VolunteerPostingsAvailabilities` page to redirect to not found page on posting error
* Updated `SchedulePostingsPage` to redirect to not found page on posting error
* Updated `branches` query only returns branches that user is in


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as employee
2. Check that you can only see postings of branches you are in
3. Log in as volunteer, and check that you can also only see postings of branches you are in


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
