### PR TITLE
Fix update user resolver to exclude branches as it is only changed by super admin via other resolvers

### DIFF
--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -130,7 +130,6 @@ const userType = gql`
     dateOfBirth: Date
     pronouns: String!
     skills: [ID!]!
-    branches: [ID!]!
     languages: [ID!]!
   }
 
@@ -160,7 +159,6 @@ const userType = gql`
     emergencyContactEmail: String
     dateOfBirth: Date
     pronouns: String!
-    branches: [ID!]!
     languages: [ID!]!
   }
 

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -964,10 +964,6 @@ class UserService implements IUserService {
           },
           data: {
             hireDate: volunteerUser.hireDate,
-            branches: {
-              set: [], // setting the related branches to be [] before connecting the passed in values
-              connect: convertToNumberIds(volunteerUser.branches),
-            },
             skills: {
               set: [], // setting the related skills to be [] before connecting the passed in values
               connect: convertToNumberIds(volunteerUser.skills),
@@ -1451,10 +1447,6 @@ class UserService implements IUserService {
               pronouns: employeeUser.pronouns,
               dateOfBirth: employeeUser.dateOfBirth,
             },
-          },
-          branches: {
-            set: [],
-            connect: convertToNumberIds(employeeUser.branches),
           },
         },
         include: {

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -77,7 +77,10 @@ export type CreateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id"> & {
   token: string;
 };
 
-export type UpdateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id">;
+export type UpdateVolunteerUserDTO = Omit<
+  VolunteerUserRequestDTO,
+  "id" | "branches"
+>;
 
 export type EmployeeUserDTO = {
   id: string;
@@ -99,7 +102,10 @@ export type CreateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id"> & {
   token: string;
 };
 
-export type UpdateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id">;
+export type UpdateEmployeeUserDTO = Omit<
+  EmployeeUserRequestDTO,
+  "id" | "branches"
+>;
 
 export type CreateUserDTO = Omit<UserDTO, "id" | "languages"> & {
   password: string;

--- a/frontend/src/components/user/AccountForm.tsx
+++ b/frontend/src/components/user/AccountForm.tsx
@@ -286,7 +286,6 @@ const AccountForm = ({
           pronouns: values.pronouns,
           dateOfBirth: values.dateOfBirth,
           languages: values.languages.map((language) => language.id),
-          branches: [],
         });
       } else {
         onVolunteerEdit({
@@ -302,7 +301,6 @@ const AccountForm = ({
           dateOfBirth: moment(values.dateOfBirth).format("YYYY-MM-DD"),
           skills: values.skills.map((skill) => skill.id),
           languages: values.languages.map((language) => language.id),
-          branches: [],
         });
       }
     }

--- a/frontend/src/types/api/UserType.ts
+++ b/frontend/src/types/api/UserType.ts
@@ -51,7 +51,10 @@ export type CreateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id"> & {
   token: string | null;
 };
 
-export type UpdateVolunteerUserDTO = Omit<VolunteerUserRequestDTO, "id">;
+export type UpdateVolunteerUserDTO = Omit<
+  VolunteerUserRequestDTO,
+  "id" | "branches"
+>;
 
 export type EmployeeDTO = {
   id: string;
@@ -74,7 +77,10 @@ export type CreateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id"> & {
   token: string | null;
 };
 
-export type UpdateEmployeeUserDTO = Omit<EmployeeUserRequestDTO, "id">;
+export type UpdateEmployeeUserDTO = Omit<
+  EmployeeUserRequestDTO,
+  "id" | "branches"
+>;
 
 export type UserInviteResponseDTO = {
   uuid: string;


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #664 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated update user resolvers used by all users to exclude branches as it is only used in the edit profile account and does not have a field to update branches. We use the user management page which uses other branch update resolvers instead.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login to user with a branch, update profile, user branches still persist and is no longer cleared


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
