### PR TITLE
Update languages field to use SearchSelectorField

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -196,7 +196,7 @@ const graphQLMiddlewares = {
     createBranch: authorizedByAdmin(),
     updateBranch: authorizedByAdmin(),
     deleteBranch: authorizedByAdmin(),
-    createLanguage: authorizedByAdmin(),
+    createLanguage: authorizedByAllRoles(),
     updateLanguage: authorizedByAdmin(),
     deleteLanguage: authorizedByAdmin(),
     upsertDeleteShiftSignups: authorizedByAdminAndVolunteer(),

--- a/frontend/src/components/user/AccountForm.tsx
+++ b/frontend/src/components/user/AccountForm.tsx
@@ -334,7 +334,6 @@ const AccountForm = ({
     return createdSkill;
   };
 
-
   const [createLanguage] = useMutation(CREATE_LANGUAGE, {
     refetchQueries: ["AccountForm_Languages"],
   });
@@ -552,7 +551,9 @@ const AccountForm = ({
                   deselectLanguage(language, values.languages, setFieldValue)
                 }
                 onCreateNewOption={(newLanguage) => addNewLanguage(newLanguage)}
-                onDeleteNewOption={(newLanguage) => deleteNewLanguage(newLanguage)}
+                onDeleteNewOption={(newLanguage) =>
+                  deleteNewLanguage(newLanguage)
+                }
               />
               <TextField
                 id="emergencyName"

--- a/frontend/src/components/user/AccountForm.tsx
+++ b/frontend/src/components/user/AccountForm.tsx
@@ -31,7 +31,6 @@ import {
   LanguageQueryResponse,
 } from "../../types/api/LanguageTypes";
 import TextField from "./fields/TextField";
-import SelectorField from "./fields/SelectorField";
 import SearchSelectorField from "./fields/SearchSelectorField";
 
 export enum AccountFormMode {

--- a/frontend/src/components/user/fields/SearchSelectorField.tsx
+++ b/frontend/src/components/user/fields/SearchSelectorField.tsx
@@ -181,6 +181,7 @@ const SearchSelectorField = ({
                         if (option.id !== "-1") { // User-added values have an id of "-1" before submitting
                           onSelect(option.id);
                         }
+                        setTextboxInput("");
                       }}
                     >
                       {option.name}

--- a/frontend/src/components/user/fields/SearchSelectorField.tsx
+++ b/frontend/src/components/user/fields/SearchSelectorField.tsx
@@ -178,7 +178,8 @@ const SearchSelectorField = ({
                       cursor="pointer"
                       onMouseDown={() => {
                         setDropdownClicked(true);
-                        if (option.id !== "-1") { // User-added values have an id of "-1" before submitting
+                        if (option.id !== "-1") {
+                          // User-added values have an id of "-1" before submitting
                           onSelect(option.id);
                         }
                         setTextboxInput("");


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your issue number -->
Closes #591, #666


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Replaced SelectorField with SearchSelectorField for languages in the AccountForm, and added all necessary dependencies, very similar to the skills SearchSelectorField implementation


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login as a volunteer or employee
2. Navigate to the Edit Profile page and test the languages field
3. Note: You won't be able to actually submit the changes if using the Firebase hosting link below since that does not include the backend changes in the preview. Testing locally works fine.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness
* Similarity with the SearchSelectorField for adding skills
* Ensuring all code for the languages field implementation doesn't still say "skills" anywhere


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
